### PR TITLE
FIx Kin flow: only charge once per subscription

### DIFF
--- a/app/src/main/java/com/psiphon3/kin/KinManager.java
+++ b/app/src/main/java/com/psiphon3/kin/KinManager.java
@@ -55,7 +55,7 @@ public class KinManager {
                                 // On opt in try and charge connection fee.
                                 if (isOptedIn) {
                                     // Charge only once per subscription run.
-                                    if(hasBeenCharged.compareAndSet(true, true)) {
+                                    if(hasBeenCharged.getAndSet(true)) {
                                         return Maybe.empty();
                                     }
                                     return clientHelper.getAccount()


### PR DESCRIPTION
Low risk fix for multiple kin charges when tunnel reconnects automatically.