### PR TITLE
Start service bug fix

### DIFF
--- a/app/src/main/java/com/psiphon3/psiphonlibrary/MainBase.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/MainBase.java
@@ -1643,12 +1643,14 @@ public abstract class MainBase {
             // when services are not allowed, such as not in foreground
             try {
                 ContextCompat.startForegroundService(this, intent);
-            } catch(IllegalStateException e) {
-                // do nothing
-            }
-
-            if (bindService(intent, m_tunnelServiceConnection, 0)) {
-                m_boundToTunnelService = true;
+                if (bindService(intent, m_tunnelServiceConnection, 0)) {
+                    m_boundToTunnelService = true;
+                }
+            } catch (IllegalStateException | SecurityException e) {
+                // Also log to diagnostics
+                MyLog.g("startAndBindTunnelService failed with error: " + e);
+                // If service fails to start notify all tunnel state observers with 'not running' state
+                onTunnelConnectionState(new TunnelManager.State());
             }
         }
 


### PR DESCRIPTION
- Catch security exception as well as illegal state exception and log the error
- Do not bind if service failed to start.  If we fail to start the service and then call  `bindService` it will cause the service to be reported as running when we call `isServiceRunning()` even though we do not use ` BIND_AUTO_CREATE` flag, which then will mess up app's UI state even further.
- Notify all observers if we failed to start service in order to bail out of "Waiting..." UI state.