### PR TITLE
TunnelServiceInteractor binding behaviour minor change

### DIFF
--- a/app/src/main/java/com/psiphon3/psiphonlibrary/MainBase.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/MainBase.java
@@ -798,6 +798,14 @@ public abstract class MainBase {
                             this.getClass()));
                 }
             }
+
+            // Update the state of UI when resuming the activity with latest tunnel state.
+            // This will ensure proper state of the VPN toggle button if user clicked Cancel Request
+            // on the VPN permission prompt, for example.
+            compositeDisposable.add(tunnelServiceInteractor.tunnelStateFlowable()
+                    .firstOrError()
+                    .doOnSuccess(this::updateServiceStateUI)
+                    .subscribe());
         }
 
         private void handleNfcIntent(Intent intent) {

--- a/app/src/main/java/com/psiphon3/psiphonlibrary/MainBase.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/MainBase.java
@@ -743,11 +743,22 @@ public abstract class MainBase {
             Toast.makeText(this, message, Toast.LENGTH_LONG).show();
         }
 
+        @Override
+        protected void onStart() {
+            super.onStart();
+            tunnelServiceInteractor.onStart(getApplicationContext());
+        }
+
+        @Override
+        protected void onStop() {
+            super.onStop();
+            tunnelServiceInteractor.onStop(getApplicationContext());
+        }
 
         @Override
         protected void onDestroy() {
             super.onDestroy();
-
+            tunnelServiceInteractor.onDestroy(getApplicationContext());
             if (m_sponsorHomePage != null) {
                 m_sponsorHomePage.stop();
                 m_sponsorHomePage = null;
@@ -768,8 +779,6 @@ public abstract class MainBase {
 
             // Load new logs from the logging provider when it changes
             getContentResolver().registerContentObserver(LoggingProvider.INSERT_URI, true, m_loggingObserver);
-
-            tunnelServiceInteractor.resume(getApplicationContext());
 
             // Don't show the keyboard until edit selected
             getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN);
@@ -829,7 +838,6 @@ public abstract class MainBase {
             super.onPause();
             getContentResolver().unregisterContentObserver(m_loggingObserver);
             cancelInvalidProxySettingsToast();
-            tunnelServiceInteractor.pause(getApplicationContext());
         }
 
         protected void doToggle() {

--- a/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelServiceInteractor.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelServiceInteractor.java
@@ -56,6 +56,7 @@ import static android.content.Context.ACTIVITY_SERVICE;
 
 public class TunnelServiceInteractor {
     private static final String SERVICE_STARTING_BROADCAST_INTENT = "SERVICE_STARTING_BROADCAST_INTENT";
+    private final BroadcastReceiver broadcastReceiver;
     private Relay<TunnelState> tunnelStateRelay = BehaviorRelay.<TunnelState>create().toSerialized();
     private Relay<Boolean> dataStatsRelay = PublishRelay.<Boolean>create().toSerialized();
     private Relay<Boolean> knownRegionsRelay = PublishRelay.<Boolean>create().toSerialized();
@@ -65,19 +66,18 @@ public class TunnelServiceInteractor {
     private Disposable restartServiceDisposable = null;
 
     private Rx2ServiceBindingFactory serviceBindingFactory;
-
-    private boolean isPaused = true;
+    private boolean isStopped = true;
 
     public TunnelServiceInteractor(Context context) {
         // Listen to SERVICE_STARTING_BROADCAST_INTENT broadcast that may be sent by another instance
         IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction(SERVICE_STARTING_BROADCAST_INTENT);
-        BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
+        this.broadcastReceiver = new BroadcastReceiver() {
             @Override
             public void onReceive(Context context, Intent intent) {
                 String action = intent.getAction();
                 if (action != null) {
-                    if (action.equals(SERVICE_STARTING_BROADCAST_INTENT) && !isPaused) {
+                    if (action.equals(SERVICE_STARTING_BROADCAST_INTENT) && !isStopped) {
                         bindTunnelService(context, intent);
                     }
                 }
@@ -86,8 +86,8 @@ public class TunnelServiceInteractor {
         LocalBroadcastManager.getInstance(context).registerReceiver(broadcastReceiver, intentFilter);
     }
 
-    public void resume(Context context) {
-        isPaused = false;
+    public void onStart(Context context) {
+        isStopped = false;
         tunnelStateRelay.accept(TunnelState.unknown());
         String serviceName = getRunningService(context);
         if (serviceName != null) {
@@ -103,13 +103,17 @@ public class TunnelServiceInteractor {
         }
     }
 
-    public void pause(Context context) {
-        isPaused = true;
+    public void onStop(Context context) {
+        isStopped = true;
         tunnelStateRelay.accept(TunnelState.unknown());
         if (serviceBindingFactory != null) {
             sendServiceMessage(TunnelManager.ClientToServiceMessage.UNREGISTER.ordinal(), null);
             serviceBindingFactory.unbind(context);
         }
+    }
+
+    public void onDestroy(Context context) {
+        LocalBroadcastManager.getInstance(context).unregisterReceiver(broadcastReceiver);
     }
 
     public void startTunnelService(Context context, boolean wantVPN) {


### PR DESCRIPTION
Binding and unbinding service with onStart and onStop respectively, instead of onResume and onPause since onResume and onPause behave differently on Android 10, see https://developer.android.com/about/versions/10/highlights

>Android 10 adds a number of improvements in onResume and onPause to support multi-resume and notify your app when it has focus...
>Starting with Build.VERSION_CODES.Q there can be multiple resumed activities in the system simultaneously, so onTopResumedActivityChanged(boolean) should be used for that purpose instead. 