### PR TITLE
Bug fixes

### DIFF
--- a/app/src/main/java/com/psiphon3/StatusActivity.java
+++ b/app/src/main/java/com/psiphon3/StatusActivity.java
@@ -257,6 +257,10 @@ public class StatusActivity
         billingViewModel.queryCurrentSubscriptionStatus();
         billingViewModel.queryAllSkuDetails();
 
+        // Notify tunnel service if it is running so it may trigger purchase check and
+        // upgrade current connection if there is a new valid subscription purchase.
+        tunnelServiceInteractor.onResume();
+
         boolean isFirstRun = shouldAutoStart();
         preventAutoStart();
 

--- a/app/src/main/java/com/psiphon3/psiphonlibrary/MainBase.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/MainBase.java
@@ -200,8 +200,6 @@ public abstract class MainBase {
         protected TunnelServiceInteractor tunnelServiceInteractor;
         private Disposable handleNfcIntentDisposable;
 
-        protected boolean isAppInForeground;
-
         public TabbedActivityBase() {
             Utils.initializeSecureRandom();
         }
@@ -855,8 +853,6 @@ public abstract class MainBase {
         protected void onResume() {
             super.onResume();
 
-            isAppInForeground = true;
-            
             // Load new logs from the logging provider now
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
                 m_loggingObserver.dispatchChange(false, LoggingProvider.INSERT_URI);
@@ -924,8 +920,6 @@ public abstract class MainBase {
         @Override
         protected void onPause() {
             super.onPause();
-
-            isAppInForeground = false;
 
             getContentResolver().unregisterContentObserver(m_loggingObserver);
             cancelInvalidProxySettingsToast();

--- a/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
@@ -96,6 +96,7 @@ public class TunnelManager implements PsiphonTunnel.HostService, MyLog.ILogger, 
         RESTART_SERVICE,
         NFC_CONNECTION_INFO_EXCHANGE_EXPORT,
         NFC_CONNECTION_INFO_EXCHANGE_IMPORT,
+        ON_RESUME,
     }
 
     // Service -> Client
@@ -661,7 +662,6 @@ public class TunnelManager implements PsiphonTunnel.HostService, MyLog.ILogger, 
                         }
                         manager.mClients.add(client);
                         manager.m_newClientPublishRelay.accept(new Object());
-                        manager.purchaseVerifier.queryCurrentSubscriptionStatus();
 
                         // When new client binds also sync locale
                         setLocale(manager);
@@ -707,6 +707,9 @@ public class TunnelManager implements PsiphonTunnel.HostService, MyLog.ILogger, 
                         manager.handleNfcConnectionInfoExchangeExport();
                     }
                     break;
+
+                case ON_RESUME:
+                    manager.purchaseVerifier.queryCurrentSubscriptionStatus();
 
                 default:
                     super.handleMessage(msg);

--- a/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelServiceInteractor.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelServiceInteractor.java
@@ -115,6 +115,10 @@ public class TunnelServiceInteractor {
         }
     }
 
+    public void onResume() {
+        sendServiceMessage(TunnelManager.ClientToServiceMessage.ON_RESUME.ordinal(), null);
+    }
+
     public void onDestroy(Context context) {
         LocalBroadcastManager.getInstance(context).unregisterReceiver(broadcastReceiver);
     }


### PR DESCRIPTION
Minor and common for all branches:
- Some tightening in the TunnelServiceInteractor
- Reset UI to proper state when start up countdown but the service hasn't started because user cancelled VPN permission prompt, for example - fixes the button displaying last countdown value on finished countdown.

Important and Pro only: 
- Trigger subscription check in the service when app resumes. Old  behaviour was to run the check every time when activity binds, which was done in the activity's `onResume`. Now the activity no longer binds on `onResume` but `onStart` which would cause us to miss a new purchase.
