### PR TITLE
Start up countdown UI fix

### DIFF
--- a/app/src/main/java/com/psiphon3/StatusActivity.java
+++ b/app/src/main/java/com/psiphon3/StatusActivity.java
@@ -79,7 +79,6 @@ public class StatusActivity
     private boolean m_firstRun = true;
 
     private PsiphonAdManager psiphonAdManager;
-    private Disposable startUpInterstitialDisposable;
     private boolean disableInterstitialOnNextTabChange;
 
     private CompositeDisposable compositeDisposable = new CompositeDisposable();


### PR DESCRIPTION
Do not update UI with latest tunnel state in onResume if we are in process of starting a tunnel service.