### PR TITLE
Start up countdown UI fix

### DIFF
--- a/app/src/main/java/com/psiphon3/StatusActivity.java
+++ b/app/src/main/java/com/psiphon3/StatusActivity.java
@@ -102,7 +102,6 @@ public class StatusActivity extends com.psiphon3.psiphonlibrary.MainBase.TabbedA
     private PsiCashFragment psiCashFragment;
 
     private PsiphonAdManager psiphonAdManager;
-    private Disposable startUpInterstitialDisposable;
     private boolean disableInterstitialOnNextTabChange;
     private Disposable autoStartDisposable;
 


### PR DESCRIPTION
Do not update UI with latest tunnel state in onResume if we are in process of starting a tunnel service.