### PR TITLE
Bug fix: make sure doStartUp() is always called on the main thread + hyprMX MoPub adapter 5.0.5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,6 +13,10 @@ android {
         maven {
             url "https://maven.google.com"
         }
+        maven {
+            //HyprMX repo
+            url "https://raw.githubusercontent.com/HyprMXMobile/Android-SDKs/master"
+        }
     }
 
     def versionPropsFile = new File('version.properties')
@@ -159,6 +163,7 @@ dependencies {
     implementation "com.google.android.gms:play-services-ads:$rootProject.ext.playServicesAdsVersion"
     implementation "com.mopub.mediation:admob:$rootProject.ext.mopubMediationAdmobVersion"
     implementation "com.google.android.ads.consent:consent-library:$rootProject.ext.adsConsentLibraryVersion"
+    implementation "com.hyprmx.android:HyprMX-MoPub:$rootProject.ext.hyprMXMoPubVersion"
 
     implementation "io.reactivex.rxjava2:rxandroid:$rootProject.ext.rxandroidVersion"
     implementation "io.reactivex.rxjava2:rxjava:$rootProject.ext.rxjavaVersion"

--- a/app/src/main/java/com/psiphon3/StatusActivity.java
+++ b/app/src/main/java/com/psiphon3/StatusActivity.java
@@ -268,6 +268,7 @@ public class StatusActivity extends com.psiphon3.psiphonlibrary.MainBase.TabbedA
 
         if (autoStartDisposable == null || autoStartDisposable.isDisposed()) {
             autoStartDisposable = autoStartMaybe(isFirstRun)
+                    .observeOn(AndroidSchedulers.mainThread())
                     .doOnSuccess(__ -> doStartUp())
                     .subscribe();
             compositeDisposable.add(autoStartDisposable);
@@ -473,6 +474,7 @@ public class StatusActivity extends com.psiphon3.psiphonlibrary.MainBase.TabbedA
                 // ambWith mirrors the ObservableSource that first either emits an
                 // item or sends a termination notification.
                 .ambWith(interstitial)
+                .observeOn(AndroidSchedulers.mainThread())
                 // On error just complete this subscription which then will start the service.
                 .onErrorResumeNext(err -> {
                     return Observable.empty();

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ ext {
     testRunnerVersion = '0.5'
     playStoreBillingClientVersion = '2.2.0'
     threetenabpVersion = '1.2.1'
+    hyprMXMoPubVersion = '5.0.5'
 }
 
 subprojects {


### PR DESCRIPTION
Fixes a crash when proceedTunnel() is trying to show a toast on a non-UI thread