### PR TITLE
Disallowed traffic alerts changes

### DIFF
--- a/app/src/main/java/com/psiphon3/StatusActivity.java
+++ b/app/src/main/java/com/psiphon3/StatusActivity.java
@@ -381,8 +381,24 @@ public class StatusActivity extends com.psiphon3.psiphonlibrary.MainBase.TabbedA
             // OK to be null because we don't use it
             onGetHelpConnectingClick(null);
         } else if (0 == intent.getAction().compareTo(TunnelManager.INTENT_ACTION_DISALLOWED_TRAFFIC)) {
-            // Switch to home tab where payment options are provided
-            m_tabHost.setCurrentTabByTag(HOME_TAB_TAG);
+            LayoutInflater inflater = this.getLayoutInflater();
+            View dialogView = inflater.inflate(R.layout.disallowed_traffic_alert_layout, null);
+            new AlertDialog.Builder(this)
+                    .setCancelable(true)
+                    .setIcon(R.drawable.ic_psiphon_alert_notification)
+                    .setTitle(R.string.disallowed_traffic_alert_notification_title)
+                    .setView(dialogView)
+                    .setPositiveButton(R.string.btn_get_subscription, (dialog, which) -> {
+                        onSubscribeButtonClick(null);
+                        dialog.dismiss();
+                    })
+                    .setNegativeButton(R.string.btn_get_speed_boost, (dialog, which) -> {
+                        if (psiCashFragment != null) {
+                            psiCashFragment.openPsiCashStoreActivity(getResources().getInteger(R.integer.speedBoostTabIndex));
+                        }
+                        dialog.dismiss();
+                    })
+                    .show();
         }
     }
 

--- a/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
@@ -424,6 +424,11 @@ public class TunnelManager implements PsiphonTunnel.HostService, MyLog.ILogger, 
         cancelGetHelpConnecting();
         cancelOpenAppToFinishConnectingNotification();
 
+        // Also cancel disallowed traffic alert notification
+        if (mNotificationManager != null) {
+            mNotificationManager.cancel(R.id.notification_id_disallowed_traffic_alert);
+        }
+
         stopAndWaitForTunnel();
         MyLog.unsetLogger();
         m_compositeDisposable.dispose();

--- a/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
@@ -420,19 +420,21 @@ public class TunnelManager implements PsiphonTunnel.HostService, MyLog.ILogger, 
             // Only cancel our own service notifications, do not cancel _all_ notifications.
             mNotificationManager.cancel(R.string.psiphon_service_notification_id);
         }
-        // Cancel "get help" and "open app to finish connecting" notifications too.
+        // Cancel "get help", "open app to finish connecting" and "disallowed traffic alert" notifications.
         cancelGetHelpConnecting();
         cancelOpenAppToFinishConnectingNotification();
-
-        // Also cancel disallowed traffic alert notification
-        if (mNotificationManager != null) {
-            mNotificationManager.cancel(R.id.notification_id_disallowed_traffic_alert);
-        }
+        cancelDisallowedTrafficAlertNotification();
 
         stopAndWaitForTunnel();
         MyLog.unsetLogger();
         m_compositeDisposable.dispose();
         purchaseVerifier.onDestroy();
+    }
+
+    private void cancelDisallowedTrafficAlertNotification() {
+        if (mNotificationManager != null) {
+            mNotificationManager.cancel(R.id.notification_id_disallowed_traffic_alert);
+        }
     }
 
     void onRevoke() {
@@ -1610,6 +1612,8 @@ public class TunnelManager implements PsiphonTunnel.HostService, MyLog.ILogger, 
                         "google-subscription".equals(a.accessType()) ||
                         "speed-boost".equals(a.accessType())) {
                     hasBoostOrSubscription = true;
+                    // Also cancel disallowed traffic alert notification
+                    cancelDisallowedTrafficAlertNotification();
                     break;
                 }
             }

--- a/app/src/main/res/layout/disallowed_traffic_alert_layout.xml
+++ b/app/src/main/res/layout/disallowed_traffic_alert_layout.xml
@@ -11,7 +11,6 @@
         android:paddingVertical="8dp">
 
         <TextView
-            android:id="@+id/legacy_mode_alert_tv"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:justificationMode="inter_word"

--- a/app/src/main/res/layout/disallowed_traffic_alert_layout.xml
+++ b/app/src/main/res/layout/disallowed_traffic_alert_layout.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingHorizontal="16dp"
+        android:paddingVertical="8dp">
+
+        <TextView
+            android:id="@+id/legacy_mode_alert_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:justificationMode="inter_word"
+            android:lineSpacingExtra="4dp"
+            android:padding="4dp"
+            android:text="@string/disallowed_traffic_alert_dialog_message" />
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/values/pro-strings.xml
+++ b/app/src/main/res/values/pro-strings.xml
@@ -303,11 +303,23 @@
     indicates a fast or unrestricted speed.-->
     <string name="speed_boost_insufficient_balance_alert">You do not have enough PsiCash to activate this Speed Boost option, would you like to add some?</string>
 
-    <!-- Title of the notification which is shown to the user when Psiphon server detects an unsupported Internet traffic request  -->
+    <!-- Title of the tolbar notification which is shown to the user when Psiphon server detects an unsupported Internet traffic request  -->
     <string name="disallowed_traffic_alert_notification_title">Upgrade Psiphon Pro</string>
 
-    <!-- Content of the notification which is shown to the user when Psiphon server detects an unsupported Internet traffic request  -->
-    <string name="disallowed_traffic_alert_notification_message">Some Internet traffic is not supported by the free version of Psiphon Pro. Purchase a subscription or Speed Boost to unlock the full potential of your Psiphon experience.</string>
+    <!-- Content of the toolbar notification which is shown to the user when Psiphon server detects an unsupported Internet traffic request  -->
+    <string name="disallowed_traffic_alert_notification_message">Apps not working? Click here to improve your Psiphon experience!</string>
+
+    <!-- Content of the alert dialog which is shown to the user when they click toolbar notification of unsupported Internet traffic request  -->
+    <string name="disallowed_traffic_alert_dialog_message">Some Internet traffic is not supported by the free version of Psiphon Pro. Purchase a subscription or Speed Boost to unlock the full potential of your Psiphon experience.</string>
+
+    <!-- Text on the button which takes user to subscription screen -->
+    <string name="btn_get_subscription">Subscribe</string>
+
+    <!-- Text on the button which takes user to Speed Boost screen.
+    'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through
+    Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that
+    indicates a fast or unrestricted speed.-->
+    <string name="btn_get_speed_boost">Speed Boost</string>
 
     <!-- A message with numeric formatter such as "1 hour" or "5 hours", translate for all language applicable forms. -->
     <plurals name="hours_of_speed_boost">


### PR DESCRIPTION
- Display a modal alert in main UI when user clicks toolbar 'disallowed alert' notification.
- Dismiss the notification when service stops.
- Dismiss the notification when server detects user has new subscription or speed boost.