### PR TITLE
Bug fix: do not leak broadcast receiver

### DIFF
--- a/app/src/main/java/com/psiphon3/psiphonlibrary/MainBase.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/MainBase.java
@@ -494,6 +494,7 @@ public abstract class MainBase {
                 m_sponsorHomePage = null;
             }
             compositeDisposable.dispose();
+            LocalBroadcastManager.getInstance(this).unregisterReceiver(broadcastReceiver);
         }
 
         protected void setupActivityLayout() {


### PR DESCRIPTION
Unregister broadcast receiver responsible for tunnel restart when a Speed Boost is activated when activity is destroyed. Otherwise it may leak and call tunnel restart multiple times.