### PR TITLE
Fix NPE caused by showing disallowed traffic alerts to some subscribers

### DIFF
--- a/app/src/main/java/com/psiphon3/StatusActivity.java
+++ b/app/src/main/java/com/psiphon3/StatusActivity.java
@@ -98,9 +98,6 @@ public class StatusActivity extends com.psiphon3.psiphonlibrary.MainBase.TabbedA
 
     private boolean m_tunnelWholeDevicePromptShown = false;
     private boolean m_firstRun = true;
-
-    private PsiCashFragment psiCashFragment;
-
     private PsiphonAdManager psiphonAdManager;
     private boolean disableInterstitialOnNextTabChange;
     private Disposable autoStartDisposable;
@@ -384,7 +381,10 @@ public class StatusActivity extends com.psiphon3.psiphonlibrary.MainBase.TabbedA
         } else if (0 == intent.getAction().compareTo(TunnelManager.INTENT_ACTION_DISALLOWED_TRAFFIC)) {
             LayoutInflater inflater = this.getLayoutInflater();
             View dialogView = inflater.inflate(R.layout.disallowed_traffic_alert_layout, null);
-            new AlertDialog.Builder(this)
+            final PsiCashFragment psiCashFragment =
+                    (PsiCashFragment) getSupportFragmentManager().findFragmentByTag("PsiCashFragment");
+
+            AlertDialog.Builder builder = new AlertDialog.Builder(this)
                     .setCancelable(true)
                     .setIcon(R.drawable.ic_psiphon_alert_notification)
                     .setTitle(R.string.disallowed_traffic_alert_notification_title)
@@ -392,14 +392,14 @@ public class StatusActivity extends com.psiphon3.psiphonlibrary.MainBase.TabbedA
                     .setPositiveButton(R.string.btn_get_subscription, (dialog, which) -> {
                         onSubscribeButtonClick(null);
                         dialog.dismiss();
-                    })
-                    .setNegativeButton(R.string.btn_get_speed_boost, (dialog, which) -> {
-                        if (psiCashFragment != null) {
-                            psiCashFragment.openPsiCashStoreActivity(getResources().getInteger(R.integer.speedBoostTabIndex));
-                        }
-                        dialog.dismiss();
-                    })
-                    .show();
+                    });
+            if (psiCashFragment != null) {
+                builder.setNegativeButton(R.string.btn_get_speed_boost, (dialog, which) -> {
+                    psiCashFragment.openPsiCashStoreActivity(getResources().getInteger(R.integer.speedBoostTabIndex));
+                    dialog.dismiss();
+                });
+            }
+            builder.show();
         }
     }
 
@@ -745,8 +745,7 @@ public class StatusActivity extends com.psiphon3.psiphonlibrary.MainBase.TabbedA
         if (subscriptionState.hasValidPurchase()) {
             transaction.replace(R.id.psicash_fragment_container, new PsiCashSubscribedFragment());
         } else {
-            psiCashFragment = new PsiCashFragment();
-            transaction.replace(R.id.psicash_fragment_container, psiCashFragment);
+            transaction.replace(R.id.psicash_fragment_container, new PsiCashFragment(), "PsiCashFragment");
         }
         // Allow transaction to be committed even after FragmentManager has saved its state.
         // In case the host activity is killed and re-created this function will be called again
@@ -862,7 +861,8 @@ public class StatusActivity extends com.psiphon3.psiphonlibrary.MainBase.TabbedA
                     startUp();
                 }
             }
-            if(psiCashFragment != null) {
+            PsiCashFragment psiCashFragment = (PsiCashFragment) getSupportFragmentManager().findFragmentByTag("PsiCashFragment");
+            if (psiCashFragment != null) {
                 psiCashFragment.onActivityResult(requestCode, resultCode, data);
             }
         } else {

--- a/app/src/main/java/com/psiphon3/psicash/PsiCashFragment.java
+++ b/app/src/main/java/com/psiphon3/psicash/PsiCashFragment.java
@@ -36,6 +36,7 @@ import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.Snackbar;
 import android.support.design.widget.SwipeDismissBehavior;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v7.app.AlertDialog;
 import android.util.Pair;
@@ -149,10 +150,14 @@ public class PsiCashFragment extends Fragment implements MviView<PsiCashIntent, 
     }
 
     public void openPsiCashStoreActivity(int tabIndex) {
+        final FragmentActivity activity = getActivity();
+        if (activity == null) {
+            return;
+        }
         Intent intent = new Intent(getActivity(), PsiCashStoreActivity.class);
         intent.putExtra("tabIndex", tabIndex);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-        getActivity().startActivityForResult(intent, PSICASH_STORE_ACTIVITY);
+        activity.startActivityForResult(intent, PSICASH_STORE_ACTIVITY);
     }
 
     @Override

--- a/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
@@ -1609,7 +1609,7 @@ public class TunnelManager implements PsiphonTunnel.HostService, MyLog.ILogger, 
             hasBoostOrSubscription = false;
             for (Authorization a : acceptedAuthorizations) {
                 if ("google-subscription".equals(a.accessType()) ||
-                        "google-subscription".equals(a.accessType()) ||
+                        "google-subscription-limited".equals(a.accessType()) ||
                         "speed-boost".equals(a.accessType())) {
                     hasBoostOrSubscription = true;
                     // Also cancel disallowed traffic alert notification
@@ -1632,6 +1632,14 @@ public class TunnelManager implements PsiphonTunnel.HostService, MyLog.ILogger, 
         // Note that this is an extra measure preventing accidental server alerts since
         // the user with this auth type should not be receiving any from the server
         if (hasBoostOrSubscription) {
+            return;
+        }
+
+        // Also do not show the alert if the current tunnel config sponsor ID
+        // is set to SUBSCRIPTION_SPONSOR_ID. The user may be a legit subscriber
+        // in a process of purchase verification.
+        if (m_tunnelConfig != null &&
+                BuildConfig.SUBSCRIPTION_SPONSOR_ID.equals(m_tunnelConfig.sponsorId)) {
             return;
         }
 


### PR DESCRIPTION
- Do not show SpeedBoost button in traffic alert dialog if PsiCashFragment is null
- Make PsiCashFragment.openPsiCashStoreActivity no-op if host activity is null
- Do not show traffic alerts while subscription sponsor ID is set in current tunnel config
- Add missing 'google-subscription-limited' check in TunnelManager