### PR TITLE
More language selection fixes

### DIFF
--- a/app/src/main/java/com/psiphon3/MainActivityViewModel.java
+++ b/app/src/main/java/com/psiphon3/MainActivityViewModel.java
@@ -77,6 +77,10 @@ public class MainActivityViewModel extends AndroidViewModel implements Lifecycle
         tunnelServiceInteractor.scheduleRunningTunnelServiceRestart(context);
     }
 
+    public void sendLocaleChangedMessage() {
+        tunnelServiceInteractor.sendLocaleChangedMessage();
+    }
+
     // Basic check of proxy settings values
     public boolean validateCustomProxySettings() {
         boolean useHTTPProxyPreference = UpstreamProxySettings.getUseHTTPProxy(context);

--- a/app/src/main/java/com/psiphon3/OptionsTabFragment.java
+++ b/app/src/main/java/com/psiphon3/OptionsTabFragment.java
@@ -216,6 +216,8 @@ public class OptionsTabFragment extends PsiphonPreferenceFragmentCompat {
         }
 
         if (data != null && data.getBooleanExtra(MoreOptionsPreferenceActivity.INTENT_EXTRA_LANGUAGE_CHANGED, false)) {
+            // Signal the service to update notifications with new language
+            viewModel.sendLocaleChangedMessage();
             // This is a bit of a weird hack to cause a restart, but it works
             // Previous attempts to use the alarm manager or others caused a variable amount of wait (up to about a second)
             // before the activity would relaunch. This *seems* to provide the best functionality across phones.

--- a/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelServiceInteractor.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelServiceInteractor.java
@@ -150,6 +150,10 @@ public class TunnelServiceInteractor {
         commandTunnelRestart();
     }
 
+    public void sendLocaleChangedMessage() {
+        sendServiceMessage(TunnelManager.ClientToServiceMessage.CHANGED_LOCALE.ordinal(), null);
+    }
+
     public Flowable<TunnelState> tunnelStateFlowable() {
         return tunnelStateRelay
                 .distinctUntilChanged()


### PR DESCRIPTION
Set locale in the TunnelManager only when the tunnel starts or the
activity signals to a running service that the in-app locale has changed