### PR TITLE
ActivityNotFoundException crash fixes

### DIFF
--- a/app/src/main/java/com/psiphon3/psiphonlibrary/MoreOptionsPreferenceActivity.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/MoreOptionsPreferenceActivity.java
@@ -20,6 +20,7 @@
 package com.psiphon3.psiphonlibrary;
 
 import android.app.ProgressDialog;
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
@@ -243,9 +244,15 @@ public class MoreOptionsPreferenceActivity extends LocalizedActivities.AppCompat
         }
 
         private void setupAbout(PreferenceScreen preferences) {
-            Preference pref = preferences.findPreference(getString(R.string.preferenceAbout));
-            Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(EmbeddedValues.INFO_LINK_URL));
-            pref.setIntent(browserIntent);
+            final Preference pref = preferences.findPreference(getString(R.string.preferenceAbout));
+            final Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(EmbeddedValues.INFO_LINK_URL));
+            pref.setOnPreferenceClickListener(preference -> {
+                try {
+                    requireContext().startActivity(browserIntent);
+                } catch (ActivityNotFoundException ignored) {
+                }
+                return true;
+            });
         }
 
         private void exportZircoHistoryBookmarks() {

--- a/app/src/main/java/com/psiphon3/psiphonlibrary/VpnOptionsPreferenceActivity.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/VpnOptionsPreferenceActivity.java
@@ -19,6 +19,7 @@
 
 package com.psiphon3.psiphonlibrary;
 
+import android.content.ActivityNotFoundException;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -80,9 +81,16 @@ public class VpnOptionsPreferenceActivity extends LocalizedActivities.AppCompatA
             mTunnelNotSelectedApps = (RadioButtonPreference) preferenceScreen.findPreference(getString(R.string.preferenceExcludeAppsFromVpn));
             mSelectApps = preferenceScreen.findPreference(getString(R.string.preferenceSelectApps));
 
-            Preference alwaysOnVpnPref = preferenceScreen.findPreference(getString(R.string.preferenceNavigateToVPNSetting));
+            final Preference alwaysOnVpnPref = preferenceScreen.findPreference(getString(R.string.preferenceNavigateToVPNSetting));
             if (Utils.supportsAlwaysOnVPN()) {
-                alwaysOnVpnPref.setIntent(new Intent(ACTION_VPN_SETTINGS));
+                final Intent vpnSettingsIntent = new Intent(ACTION_VPN_SETTINGS);
+                alwaysOnVpnPref.setOnPreferenceClickListener(preference -> {
+                    try {
+                        requireContext().startActivity(vpnSettingsIntent);
+                    } catch (ActivityNotFoundException ignored) {
+                    }
+                    return true;
+                });
             } else {
                 alwaysOnVpnPref.setEnabled(false);
                 alwaysOnVpnPref.setSummary(R.string.vpn_always_on_preference_not_available_summary);


### PR DESCRIPTION
Do not crash the app if the system cannot start an activity from an implicit intent