### PR TITLE
Call VpnService.Builder.setMetered(false) on API >= 29.

### DIFF
--- a/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
@@ -76,8 +76,6 @@ import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
 
-import static android.os.Build.VERSION_CODES.LOLLIPOP;
-
 public class TunnelManager implements PsiphonTunnel.HostService {
     // Android IPC messages
     // Client -> Service
@@ -924,8 +922,18 @@ public class TunnelManager implements PsiphonTunnel.HostService {
     public Builder newVpnServiceBuilder() {
         Builder vpnBuilder = ((TunnelVpnService) m_parentService).newBuilder();
         // only can control tunneling post lollipop
-        if (Build.VERSION.SDK_INT < LOLLIPOP) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             return vpnBuilder;
+        }
+
+//        Added on API 29:
+//        Marks the VPN network as metered. A VPN network is classified as metered when the user is
+//        sensitive to heavy data usage due to monetary costs and/or data limitations. In such cases,
+//        you should set this to true so that apps on the system can avoid doing large data transfers.
+//        Otherwise, set this to false. Doing so would cause VPN network to inherit its meteredness
+//        from its underlying networks.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            vpnBuilder.setMetered(false);
         }
 
         Context context = getContext();


### PR DESCRIPTION
See comments in the code.