### PR TITLE
Standardize deep links

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -103,6 +103,10 @@ com.verizon.ads.webview" />
                 <data
                     android:scheme="psiphon"
                     android:host="psicash" />
+                <!-- Accepts URIs in the form of "psiphon://settings” -->
+                <data
+                    android:scheme="psiphon"
+                    android:host="settings" />
             </intent-filter>
         </activity>
         <activity-alias

--- a/app/src/main/java/com/psiphon3/FeedbackActivity.java
+++ b/app/src/main/java/com/psiphon3/FeedbackActivity.java
@@ -52,6 +52,7 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.Toast;
 
+import androidx.appcompat.app.ActionBar;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.work.Constraints;
 import androidx.work.Data;
@@ -82,6 +83,14 @@ public class FeedbackActivity extends LocalizedActivities.AppCompatActivity
         Intent intent = getIntent();
         if (isDeepLinkIntent(intent)) {
             LoggingProvider.LogDatabaseHelper.retrieveLogs(this);
+        }
+
+        // Do not display the home button as arrow if the activity is running in a standalone mode
+        if (isTaskRoot()) {
+            ActionBar actionBar = getSupportActionBar();
+            if (actionBar != null) {
+                actionBar.setDisplayHomeAsUpEnabled(false);
+            }
         }
 
         webView = (WebView)findViewById(R.id.feedbackWebView);

--- a/app/src/main/java/com/psiphon3/MainActivity.java
+++ b/app/src/main/java/com/psiphon3/MainActivity.java
@@ -802,7 +802,7 @@ public class MainActivity extends LocalizedActivities.AppCompatActivity {
                         // If the uri path is "/buy" or "/buy/.*" then navigate to Add PsiCash tab,
                         tabIndex = getResources().getInteger(R.integer.psiCashTabIndex);
                     } else if (path.equals(PSICASH_PATH_SPEEDBOOST) || path.startsWith(PSICASH_PATH_SPEEDBOOST + FWD_SLASH)) {
-                        // TThe path is "/speedboost" or "/speedboost/.*" - navigate to SpeedBoost tab
+                        // The path is "/speedboost" or "/speedboost/.*" - navigate to SpeedBoost tab
                         tabIndex = getResources().getInteger(R.integer.speedBoostTabIndex);
                     }
                 }
@@ -814,9 +814,9 @@ public class MainActivity extends LocalizedActivities.AppCompatActivity {
             case SETTINGS_HOST:
                 selectTabByTag("settings");
                 if (path != null) {
-                    // If uri path is "/vpn" or "/vpn/.*" then navigate to VPN settings screen,
-                    // else if path is "/proxy" or "/proxy/.*" then navigate to Proxy settings screen
-                    // else if path is "/more-options" or "/more-options/.*" then navigate to More Options screen
+                    // If uri path is "/vpn" or "/vpn/.*" then signal to navigate to VPN settings screen.
+                    // If the path is "/proxy" or "/proxy/.*" then signal to navigate to Proxy settings screen.
+                    // If the path is "/more-options" or "/more-options/.*" then signal to navigate to More Options screen.
                     if (path.equals(SETTINGS_PATH_VPN) || path.startsWith(SETTINGS_PATH_VPN + FWD_SLASH)) {
                         viewModel.signalOpenVpnSettings();
                     } else if (path.equals(SETTINGS_PATH_PROXY) || path.startsWith(SETTINGS_PATH_PROXY + FWD_SLASH)) {

--- a/app/src/main/java/com/psiphon3/MainActivityViewModel.java
+++ b/app/src/main/java/com/psiphon3/MainActivityViewModel.java
@@ -10,10 +10,8 @@ import androidx.lifecycle.LifecycleObserver;
 import androidx.lifecycle.OnLifecycleEvent;
 
 import com.jakewharton.rxrelay2.PublishRelay;
-import com.psiphon3.psiphonlibrary.LoggingProvider;
 import com.psiphon3.psiphonlibrary.TunnelServiceInteractor;
 import com.psiphon3.psiphonlibrary.UpstreamProxySettings;
-import com.psiphon3.psiphonlibrary.Utils;
 
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
@@ -23,6 +21,8 @@ public class MainActivityViewModel extends AndroidViewModel implements Lifecycle
     private final PublishRelay<Boolean> customProxyValidationResultRelay = PublishRelay.create();
     private final PublishRelay<Object> availableRegionsSelectionRelay = PublishRelay.create();
     private final PublishRelay<Object> openVpnSettingsRelay = PublishRelay.create();
+    private final PublishRelay<Object> openProxySettingsRelay = PublishRelay.create();
+    private final PublishRelay<Object> openMoreOptionsRelay = PublishRelay.create();
     private PublishRelay<String> externalBrowserUrlRelay = PublishRelay.create();
     private PublishRelay<String> lastLogEntryRelay = PublishRelay.create();
     private boolean isFirstRun = true;
@@ -113,6 +113,22 @@ public class MainActivityViewModel extends AndroidViewModel implements Lifecycle
 
     public Flowable<Object> openVpnSettingsFlowable() {
         return openVpnSettingsRelay.toFlowable(BackpressureStrategy.LATEST);
+    }
+
+    public void signalOpenProxySettings() {
+        openProxySettingsRelay.accept(new Object());
+    }
+
+    public Flowable<Object> openProxySettingsFlowable() {
+        return openProxySettingsRelay.toFlowable(BackpressureStrategy.LATEST);
+    }
+
+    public void signalOpenMoreOptions() {
+        openMoreOptionsRelay.accept(new Object());
+    }
+
+    public Flowable<Object> openMoreOptionsFlowable() {
+        return openMoreOptionsRelay.toFlowable(BackpressureStrategy.LATEST);
     }
 
     public void signalExternalBrowserUrl(String url) {

--- a/app/src/main/java/com/psiphon3/OptionsTabFragment.java
+++ b/app/src/main/java/com/psiphon3/OptionsTabFragment.java
@@ -125,7 +125,8 @@ public class OptionsTabFragment extends PsiphonPreferenceFragmentCompat {
                 .doOnNext(__ -> regionListPreference.setCurrentRegionFromPreferences())
                 .subscribe();
 
-        // Observe 'Open VPN settings' button clicks from BOM legacy alert dialog.
+        // Observe 'Open VPN settings' signal from legacy BOM dialog clicks or from
+        // deep link intent handler
         viewModel.openVpnSettingsFlowable()
                 .observeOn(AndroidSchedulers.mainThread())
                 .doOnNext(__ -> {
@@ -133,6 +134,30 @@ public class OptionsTabFragment extends PsiphonPreferenceFragmentCompat {
                     if (activity != null && !activity.isFinishing()) {
                         startActivityForResult(new Intent(getActivity(),
                                 VpnOptionsPreferenceActivity.class), REQUEST_CODE_VPN_PREFERENCES);
+                    }
+                })
+                .subscribe();
+
+        // Observe 'Open Proxy settings' signal from deep link intent handler
+        viewModel.openProxySettingsFlowable()
+                .observeOn(AndroidSchedulers.mainThread())
+                .doOnNext(__ -> {
+                    final FragmentActivity activity = getActivity();
+                    if (activity != null && !activity.isFinishing()) {
+                        startActivityForResult(new Intent(getActivity(),
+                                ProxyOptionsPreferenceActivity.class), REQUEST_CODE_PROXY_PREFERENCES);
+                    }
+                })
+                .subscribe();
+
+        // Observe 'More Options' signal from deep link intent handler
+        viewModel.openMoreOptionsFlowable()
+                .observeOn(AndroidSchedulers.mainThread())
+                .doOnNext(__ -> {
+                    final FragmentActivity activity = getActivity();
+                    if (activity != null && !activity.isFinishing()) {
+                        startActivityForResult(new Intent(getActivity(),
+                                MoreOptionsPreferenceActivity.class), REQUEST_CODE_MORE_PREFERENCES);
                     }
                 })
                 .subscribe();


### PR DESCRIPTION
Add ability to navigate to either 'Add PsiCash' or 'SpeedBoost' tab from the external deep link to PsiCash store activity.

Examples
- `psiphon://psicash` -- open PsiCash store screen and switch to Add PsiCash tab(default)
- `psiphon://psicash/buy` -- open PsiCash store screen and switch to Add PsiCash tab
- `psiphon://psicash/speedboost` -- open PsiCash store screen and switch to SpeedBoost tab
- `psiphon://psicash/speedboost/extras` -- open PsiCash store screen and switch to SpeedBoost tab (`extras` param is not handled currently)
etc.

Also handle deep links in form of `psiphon://settings/*` with ability to open subsettings screens 

Examples
- `psiphon://settings` -- switch to Options tab
- `psiphon://settings/vpn` -- switch to Options tab and open VPN settings screen
- `psiphon://settings/proxy` -- switch to Options tab and open proxy settings screen
- `psiphon://settings/more-options/extras` --switch to Options tab and open More Options screen(`extras` are not handled currently)
