### PR TITLE
Fix bug in browser opening intent + more, see the comments.

### DIFF
--- a/app/src/main/java/com/psiphon3/MainActivityViewModel.java
+++ b/app/src/main/java/com/psiphon3/MainActivityViewModel.java
@@ -32,12 +32,12 @@ public class MainActivityViewModel extends AndroidViewModel implements Lifecycle
         tunnelServiceInteractor = new TunnelServiceInteractor(getApplication(), true);
     }
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
+    @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
     protected void onLifeCycleStop() {
         tunnelServiceInteractor.onStop(getApplication());
     }
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_START)
+    @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
     protected void onLifeCycleStart() {
         tunnelServiceInteractor.onStart(getApplication());
     }


### PR DESCRIPTION
- Remove package ID when building implicit browser launching intent.
- Minor refactoring and comment updates.
- Bind and unbind to/from the VPN service in `onResume` and `onPause` respectively, to minimize racing time between backgrounding the app and opening an external browser when tunnel connects. This is the way how it is done in Pro already.