### PR TITLE
UI Fixes:

### DIFF
--- a/app/src/main/java/com/psiphon3/MainActivityViewModel.java
+++ b/app/src/main/java/com/psiphon3/MainActivityViewModel.java
@@ -23,9 +23,8 @@ public class MainActivityViewModel extends AndroidViewModel implements Lifecycle
     private final PublishRelay<Object> openVpnSettingsRelay = PublishRelay.create();
     private final PublishRelay<Object> openProxySettingsRelay = PublishRelay.create();
     private final PublishRelay<Object> openMoreOptionsRelay = PublishRelay.create();
-    private PublishRelay<String> externalBrowserUrlRelay = PublishRelay.create();
-    private PublishRelay<String> lastLogEntryRelay = PublishRelay.create();
-    private boolean isFirstRun = true;
+    private final PublishRelay<String> externalBrowserUrlRelay = PublishRelay.create();
+    private final PublishRelay<String> lastLogEntryRelay = PublishRelay.create();
 
     public MainActivityViewModel(@NonNull Application application) {
         super(application);
@@ -150,14 +149,6 @@ public class MainActivityViewModel extends AndroidViewModel implements Lifecycle
 
     public Flowable<String> lastLogEntryFlowable() {
         return lastLogEntryRelay.toFlowable(BackpressureStrategy.LATEST);
-    }
-
-    public boolean isFirstRun() {
-        return isFirstRun;
-    }
-
-    public void setFirstRun(boolean firstRun) {
-        isFirstRun = firstRun;
     }
 
     public boolean isServiceRunning(Context context) {


### PR DESCRIPTION
- Fix auto-start not firing if the unsafe traffic alerts preference dialog is showing and device is rotated.
- Put unsafe traffic alerts preference dialog in a completable and chain with tunel auto-starting.
- Move `isFirst` flag to MainActivity and restore it via saved instance state to make it survive system-initiated death to prevent unwanted tunnel auto-starts.