### PR TITLE
Improve PsiCash in-app purchase UX part 1

### DIFF
--- a/app/src/main/java/com/psiphon3/billing/PurchaseVerifier.java
+++ b/app/src/main/java/com/psiphon3/billing/PurchaseVerifier.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
+import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.CompositeDisposable;
@@ -312,6 +313,21 @@ public class PurchaseVerifier {
     public void queryAllPurchases() {
         repository.startIab();
         repository.queryAllPurchases();
+    }
+
+    public Observable<Boolean> hasPendingPsiCashPurchaseObservable() {
+        return repository.purchaseStateFlowable()
+                .map(PurchaseState::purchaseList)
+                .distinctUntilChanged()
+                .toObservable()
+                .switchMap(purchaseList -> {
+                    for (Purchase purchase : purchaseList) {
+                        if (GooglePlayBillingHelper.isPsiCashPurchase(purchase)) {
+                            return Observable.just(Boolean.TRUE);
+                        }
+                    }
+                    return Observable.just(Boolean.FALSE);
+                });
     }
 
     public enum VerificationResult {

--- a/app/src/main/java/com/psiphon3/psicash/store/AddPsiCashTabFragment.java
+++ b/app/src/main/java/com/psiphon3/psicash/store/AddPsiCashTabFragment.java
@@ -391,12 +391,8 @@ public class AddPsiCashTabFragment extends Fragment {
 
             Button connectBtn = view.findViewById(R.id.continue_button);
             connectBtn.setOnClickListener(v -> {
-                try {
-                    Intent data = new Intent(MainActivity.PSICASH_CONNECT_PSIPHON_INTENT_ACTION);
-                    requireActivity().setResult(Activity.RESULT_OK, data);
-                    requireActivity().finish();
-                } catch (RuntimeException ignored) {
-                }
+                PsiCashStoreActivity psiCashStoreActivity = (PsiCashStoreActivity) requireActivity();
+                psiCashStoreActivity.getTunnelServiceInteractor().startTunnelService(psiCashStoreActivity);
             });
         }
     }

--- a/app/src/main/java/com/psiphon3/psicash/store/PsiCashStoreActivity.java
+++ b/app/src/main/java/com/psiphon3/psicash/store/PsiCashStoreActivity.java
@@ -70,6 +70,10 @@ public class PsiCashStoreActivity extends LocalizedActivities.AppCompatActivity 
         return tunnelServiceInteractor.tunnelStateFlowable();
     }
 
+    public TunnelServiceInteractor getTunnelServiceInteractor() {
+        return tunnelServiceInteractor;
+    }
+
     @SuppressLint("SourceLockedOrientationActivity")
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {

--- a/app/src/main/java/com/psiphon3/psicash/store/SpeedBoostTabFragment.java
+++ b/app/src/main/java/com/psiphon3/psicash/store/SpeedBoostTabFragment.java
@@ -323,31 +323,12 @@ public class SpeedBoostTabFragment extends Fragment {
 
                     if (balance >= priceInteger) {
                         button.setEnabled(true);
-                        speedboostItemLayout.setOnClickListener(v -> {
-                            String confirmationMessage = String.format(
-                                    requireActivity().getString(R.string.confirm_speedboost_purchase_alert),
-                                    requireActivity().getString(durationStringResId),
-                                    priceInteger
-                            );
-                            Flowable<TunnelState> tunnelStateFlowable = ((PsiCashStoreActivity) requireActivity()).tunnelStateFlowable();
-                            new AlertDialog.Builder(requireActivity())
-                                    .setIcon(R.drawable.psicash_coin)
-                                    .setTitle(requireActivity().getString(R.string.speed_boost_button_caption))
-                                    .setMessage(confirmationMessage)
-                                    .setNegativeButton(R.string.lbl_no, (dialog, which) -> {
-                                    })
-                                    .setPositiveButton(R.string.lbl_yes, (dialog, which) -> {
-                                        intentsPublishRelay.accept(PsiCashStoreIntent.PurchaseSpeedBoost.create(
-                                                tunnelStateFlowable,
-                                                price.distinguisher,
-                                                price.transactionClass,
-                                                price.price));
-                                        dialog.dismiss();
-                                    })
-                                    .setCancelable(true)
-                                    .create()
-                                    .show();
-                        });
+                        speedboostItemLayout.setOnClickListener(v -> intentsPublishRelay.accept(
+                                PsiCashStoreIntent.PurchaseSpeedBoost.create(
+                                        ((PsiCashStoreActivity) requireActivity()).tunnelStateFlowable(),
+                                        price.distinguisher,
+                                        price.transactionClass,
+                                        price.price)));
                     } else {
                         button.setEnabled(false);
                         speedboostItemLayout.setOnClickListener(v -> new AlertDialog.Builder(requireActivity())

--- a/app/src/main/res/values/pro-strings.xml
+++ b/app/src/main/res/values/pro-strings.xml
@@ -234,14 +234,6 @@
     <!-- A message to the user seen when the user just purchased PsiCash from PlayStore while connected to Psiphon and the purchase is in process of being redeemed -->
     <string name="please_wait_while_we_are_finalizing_your_purchase">Please wait while we are finalizing your purchase</string>
 
-    <!-- A prompt seen by the user when they try to use one of Speed Boost options, such as in
-    "Would you like to get 5 hours of Speed Boost for 500 PsiCash". The first format argument is the string representing a number
-    of hours as in '5 hours', the second format argument is for an integer representing the PsiCash value as in '500'
-    'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through
-    Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that
-    indicates a fast or unrestricted speed.-->
-    <string name="confirm_speedboost_purchase_alert">Would you like to get %1$s of Speed Boost for %2$d PsiCash?</string>
-
     <!-- Generic billing error message seen by user if there is a billing problem with the PsiCash purchase. Do not translate or transliterate word PsiCash -->
     <string name="psicash_purchase_not_available_error_message">PsiCash purchase is currently not available, please try again later</string>
 


### PR DESCRIPTION
- Do not dismiss PsiCash store activity when user clicks "Connect to Psiphon to finalize purchase".
- TunnelManager: do not send intents to the main activity if there is a pending PsiCash purchase to redeem.
- Remove Speed Boost purchase confirmation prompt.