### PR TITLE
Pro

### DIFF
--- a/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
@@ -322,6 +322,8 @@ public class TunnelManager implements PsiphonTunnel.HostService, PurchaseVerifie
                             // Do not emit downstream if we are just started routing.
                             return Observable.empty();
                         } else if (shouldShowPurchaseRequiredPrompt()) {
+                            // Cancel "Psiphon isn't free" notification if it still showing.
+                            cancelPurchaseRequiredNotification();
                             if (canSendIntentToActivity()) {
                                 m_tunnel.routeThroughTunnel();
                                 sendShowPurchaseRequiredIntent();

--- a/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
@@ -508,6 +508,7 @@ public class TunnelManager implements PsiphonTunnel.HostService, PurchaseVerifie
         }
         // Cancel potentially dangling notifications.
         cancelDisallowedTrafficAlertNotification();
+        cancelPurchaseRequiredNotification();
 
         stopAndWaitForTunnel();
         m_compositeDisposable.dispose();


### PR DESCRIPTION
Cancel "Purchase required" notification when:
- VPN service stops.
- Tunnel starts with either subscription or Speed Boost sponsor ID.
- We are going to force send Payment Required intent to the main activity.