### PR TITLE
Target API 34 (Android 14)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     def versionPropsFile = rootProject.file('version.properties')
 
@@ -17,7 +17,7 @@ android {
                 applicationId "com.psiphon3"
                 resValue "string", "tray__authority", "${applicationId}.tray"
                 minSdkVersion 14
-                targetSdkVersion 33
+                targetSdkVersion 34
                 versionCode verCode
                 versionName verName
                 testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,6 @@ android {
             def verName = props['VERSION_CODE']
             def verCode = verName.toInteger()
             defaultConfig {
-                project.ext.set("archivesBaseName", "PsiphonAndroid");
                 applicationId "com.psiphon3"
                 resValue "string", "tray__authority", "${applicationId}.tray"
                 minSdkVersion 14
@@ -32,6 +31,14 @@ android {
 
     signingConfigs {
         release
+    }
+
+    // Configure output APK file name
+    applicationVariants.configureEach { variant ->
+        variant.outputs.configureEach { output ->
+            def fileName = "PsiphonAndroid-${variant.buildType.name}.apk"
+            output.outputFileName = fileName
+        }
     }
 
     buildTypes {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"/>
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
     <uses-permission android:name="android.permission.NFC" />
     <uses-feature android:name="android.hardware.nfc.hce" android:required="false"/>
@@ -128,11 +129,12 @@
             android:name=".PsiphonBumpHelpActivity" />
         <service
             android:name=".psiphonlibrary.TunnelVpnService"
-            android:foregroundServiceType="location"
+            android:foregroundServiceType="specialUse"
             android:label="@string/app_name"
             android:permission="android.permission.BIND_VPN_SERVICE"
             android:exported="false"
             android:process=":TunnelVpnService" >
+            <property android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE" android:value="vpn" />
             <intent-filter>
                 <action android:name="android.net.VpnService" />
             </intent-filter>

--- a/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
@@ -31,6 +31,7 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.content.pm.ServiceInfo;
 import android.net.VpnService;
 import android.net.VpnService.Builder;
 import android.os.Build;
@@ -234,8 +235,14 @@ public class TunnelManager implements PsiphonTunnel.HostService {
             }
         }
 
-        m_parentService.startForeground(R.string.psiphon_service_notification_id,
-                createNotification(false, TunnelState.ConnectionData.NetworkConnectionState.CONNECTING));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            m_parentService.startForeground(R.string.psiphon_service_notification_id,
+                    createNotification(false, TunnelState.ConnectionData.NetworkConnectionState.CONNECTING),
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE);
+        } else {
+            m_parentService.startForeground(R.string.psiphon_service_notification_id,
+                    createNotification(false, TunnelState.ConnectionData.NetworkConnectionState.CONNECTING));
+        }
 
         m_tunnelState.isRunning = true;
         // This service runs as a separate process, so it needs to initialize embedded values

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.2.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jul 23 12:32:33 EDT 2020
+#Tue Jul 09 17:02:44 EDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip


### PR DESCRIPTION
Bump AGP to 4.2.2 to support `<property>` element in the manifest required by Google Play, see https://developer.android.com/about/versions/14/changes/fgs-types-required#special-use