### PR TITLE
Improve VPN exclusions logic

### DIFF
--- a/app/src/main/java/com/psiphon3/psiphonlibrary/VpnAppsUtils.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/VpnAppsUtils.java
@@ -237,4 +237,14 @@ public class VpnAppsUtils {
         }
         return null;
     }
+
+    // Method to check if app is installed
+    public static boolean isAppInstalled(PackageManager packageManager, String packageName) {
+        try {
+            packageManager.getApplicationInfo(packageName, 0);
+            return true;
+        } catch (PackageManager.NameNotFoundException ignored) {
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
- Replace `getApplicationInfo()` calls with `VpnAppsUtils.isAppInstalled()`.
- Restrict signature checks to installed apps only.
- Improve logging for `NameNotFoundException` when adding/excluding apps.