### PR TITLE
Fix crash due to ProGuard stripping Java method called from native code

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,6 +53,8 @@ android {
         debug {
             debuggable true
             pseudoLocalesEnabled true
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         release {
             debuggable false

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -15,3 +15,13 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+# Preserve native methods in Tun2SocksJniLoader
+-keep class ca.psiphon.Tun2SocksJniLoader {
+    native <methods>;
+}
+
+# Keep the logTun2Socks method in VpnManager, as it is called from native code
+-keep class com.psiphon3.VpnManager {
+    public static void logTun2Socks(java.lang.String, java.lang.String, java.lang.String);
+}


### PR DESCRIPTION
- Enable ProGuard minification in the debug build permanently to catch proguard related errors early.
- Add rules to preserve the logTun2Socks method in VpnManager, called from native code, and native methods in Tun2SocksJniLoader.