### PR TITLE
Include 64 bit abi for native libraries

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,7 @@ android {
                 versionCode verCode
                 versionName verName
                 testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+                multiDexEnabled true
                 vectorDrawables.useSupportLibrary = true
             }
         } else {
@@ -51,7 +52,7 @@ android {
             debuggable false
             ndk {
                 // ABI configurations of native libraries Gradle should package with the APK.
-                abiFilters 'armeabi-v7a'
+                abiFilters 'armeabi-v7a', 'arm64-v8a'
             }
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'


### PR DESCRIPTION
Newer devices, such as Pixel 7, require 64-bit native libraries