### PR TITLE
Automatic VPN restart on app updates

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -158,6 +158,13 @@
             android:exported="false"
             android:process=":LoggingContentProvider"
             android:authorities="com.psiphon3.LoggingContentProvider" />
+        <!-- PsiphonUpdateReceiver receives intents that trigger upgrade checking. -->
+        <receiver android:name=".PsiphonUpdateReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
+        </receiver>
 
         <!-- UpgradeChecker receives intents (direct, alarm, boot) that trigger upgrade checking. -->
         <receiver

--- a/app/src/main/java/com/psiphon3/PsiphonUpdateReceiver.java
+++ b/app/src/main/java/com/psiphon3/PsiphonUpdateReceiver.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024, Psiphon Inc.
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.psiphon3;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+import com.psiphon3.log.MyLog;
+import com.psiphon3.psiphonlibrary.TunnelServiceInteractor;
+
+import net.grandcentrix.tray.AppPreferences;
+
+public class PsiphonUpdateReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (Intent.ACTION_MY_PACKAGE_REPLACED.equals(intent.getAction())) {
+            MyLog.i("PsiphonUpdateReceiver: psiphon app package was updated.");
+
+            // Check if the service was running before the update and restart it if necessary
+            boolean shouldStart = new AppPreferences(context).getBoolean(context.getString(R.string.serviceRunningPreference), false);
+
+            if (shouldStart) {
+                MyLog.i("PsiphonUpdateReceiver: automatically restarting VPN service after update.");
+                TunnelServiceInteractor tunnelServiceInteractor = new TunnelServiceInteractor(context, false);
+                if (!tunnelServiceInteractor.isServiceRunning(context)) {
+                    tunnelServiceInteractor.startTunnelService(context);
+                } else {
+                    MyLog.i("PsiphonUpdateReceiver: VPN service is already running; doing nothing.");
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/psiphon_android_library_untranslated_strings.xml
+++ b/app/src/main/res/values/psiphon_android_library_untranslated_strings.xml
@@ -49,6 +49,7 @@
     <string name="status_notification_group" translatable="false">status_notification_group</string>
     <string name="vpnServiceDataCollectionDisclosureAccepted" translatable="false">vpnServiceDataCollectionDisclosureAccepted</string>
     <string name="deviceLocationPrecisionParameter" translatable="false">deviceLocationPrecision</string>
+    <string name="serviceRunningPreference" translatable="false">serviceRunningPreference</string>
 
     <string-array name="languages">
         <item>English,en</item>


### PR DESCRIPTION
Add PsiphonUpdateReceiver to trigger VPN service restarts based on persistent state flags following app updates.