### PR TITLE
Send full unlock options map with display flags in intent

### DIFF
--- a/app/src/main/java/com/psiphon3/MainActivity.java
+++ b/app/src/main/java/com/psiphon3/MainActivity.java
@@ -875,14 +875,8 @@ public class MainActivity extends LocalizedActivities.AppCompatActivity {
                     disallowedTrafficAlertDialog.dismiss();
                 }
 
-                // Get unlock options from the intent extras
-                Bundle extras = intent.getExtras();
-                ArrayList<String> unlockOptionsList = null;
-                if (extras != null) {
-                    unlockOptionsList = extras.getStringArrayList(TunnelManager.DATA_UNLOCK_OPTIONS);
-                }
                 unlockRequiredDialog = new UnlockRequiredDialog.Builder(this, this)
-                        .setUnlockOptionsList(unlockOptionsList)
+                        .setUnlockOptionsMap(UnlockOptions.fromBundle(intent.getExtras()))
                         .setDisconnectTunnelRunnable(() -> compositeDisposable.add(
                                 getTunnelServiceInteractor().tunnelStateFlowable()
                                         .filter(state -> !state.isUnknown())

--- a/app/src/main/java/com/psiphon3/UnlockOptions.java
+++ b/app/src/main/java/com/psiphon3/UnlockOptions.java
@@ -1,12 +1,13 @@
 package com.psiphon3;
 
+import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.jakewharton.rxrelay2.BehaviorRelay;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -69,14 +70,28 @@ public class UnlockOptions {
         entriesSetRelay.accept(entryMap.keySet());
     }
 
-    public List<String> getDisplayableUnlockOptions() {
-        List<String> displayable = new ArrayList<>();
+    public Bundle toBundle() {
+        Bundle bundle = new Bundle();
         for (Map.Entry<String, UnlockEntry> entry : entries.entrySet()) {
-            if (entry.getValue().isDisplayable()) {
-                displayable.add(entry.getKey());
+            Bundle entryBundle = new Bundle();
+            entryBundle.putBoolean("display", entry.getValue().isDisplayable());
+            bundle.putBundle(entry.getKey(), entryBundle);
+        }
+        return bundle;
+    }
+
+    public static Map<String, Boolean> fromBundle(@Nullable Bundle bundle) {
+        Map<String, Boolean> result = new HashMap<>();
+        if (bundle == null) {
+            return result;
+        }
+        for (String key : bundle.keySet()) {
+            Bundle entry = bundle.getBundle(key);
+            if (entry != null && entry.containsKey("display")) {
+                result.put(key, entry.getBoolean("display"));
             }
         }
-        return displayable;
+        return result;
     }
 
     public boolean hasConduitEntry() {

--- a/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
@@ -149,7 +149,6 @@ public class TunnelManager implements PsiphonTunnel.HostService, PurchaseVerifie
     public static final String DATA_UNSAFE_TRAFFIC_SUBJECTS_LIST = "dataUnsafeTrafficSubjects";
     public static final String DATA_UNSAFE_TRAFFIC_ACTION_URLS_LIST = "dataUnsafeTrafficActionUrls";
     public static final String DATA_NFC_CONNECTION_INFO_EXCHANGE = "dataNfcConnectionInfoExchange";
-    public static final String DATA_UNLOCK_OPTIONS = "unlockOptions";
 
     // a snapshot of all authorizations pulled by getPsiphonConfig
     private List<Authorization> m_tunnelConfigAuthorizations;
@@ -361,6 +360,7 @@ public class TunnelManager implements PsiphonTunnel.HostService, PurchaseVerifie
                                 .doOnNext(state -> MyLog.i("TunnelManager: Conduit state: " + state))
                                 .filter(state -> state.status() != ConduitState.Status.UNKNOWN)
                                 .map(state -> state.status() == ConduitState.Status.RUNNING)
+                                .doOnError(e -> MyLog.e("TunnelManager: Conduit state error: " + e))
                                 .onErrorReturnItem(false)
                                 .doOnNext(isRunning -> {
                                     MyLog.i("TunnelManager: updating tunnel config manager with Conduit state: " + isRunning);
@@ -513,10 +513,8 @@ public class TunnelManager implements PsiphonTunnel.HostService, PurchaseVerifie
     }
 
     private void sendUnlockRequiredIntent() {
-        Bundle bundle = new Bundle();
-        bundle.putStringArrayList(DATA_UNLOCK_OPTIONS, new ArrayList<>(unlockOptions.getDisplayableUnlockOptions()));
         PendingIntent showUnlockRequiredIntent = getPendingIntent(m_parentService,
-                INTENT_ACTION_SHOW_UNLOCK_REQUIRED, bundle);
+                INTENT_ACTION_SHOW_UNLOCK_REQUIRED, unlockOptions.toBundle());
         try {
             showUnlockRequiredIntent.send();
             // Cancel disallowed traffic alert too if it is showing


### PR DESCRIPTION
- Update UnlockRequiredDialog to use a map of unlock entries with display flags
- Add UnlockOptions.toBundle() and fromBundle() helpers