### PR TITLE
Refactor: stop tunnel service immediately upon detecting unlock required

### DIFF
--- a/app/src/main/java/com/psiphon3/UnlockOptions.java
+++ b/app/src/main/java/com/psiphon3/UnlockOptions.java
@@ -1,13 +1,29 @@
 package com.psiphon3;
 
+import android.content.Context;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.jakewharton.rxrelay2.BehaviorRelay;
+import com.psiphon3.log.MyLog;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -19,6 +35,10 @@ import io.reactivex.Flowable;
 public class UnlockOptions {
     public static final String UNLOCK_ENTRY_SUBSCRIPTION = "Subscription";
     public static final String UNLOCK_ENTRY_CONDUIT = "Conduit";
+    // File persistence constants
+    private static final String UNLOCK_OPTIONS_FILE = "unlock_options.json";
+    private static final String UNLOCK_OPTIONS_TEMP_FILE = "unlock_options_temp.json";
+    private static final String UNLOCK_OPTIONS_LOCK_FILE = "unlock_options.lock";
 
     private final Map<String, UnlockEntry> entries = new ConcurrentHashMap<>();
     private final BehaviorRelay<Set<String>> entriesSetRelay = BehaviorRelay.create();
@@ -70,28 +90,183 @@ public class UnlockOptions {
         entriesSetRelay.accept(entryMap.keySet());
     }
 
-    public Bundle toBundle() {
-        Bundle bundle = new Bundle();
-        for (Map.Entry<String, UnlockEntry> entry : entries.entrySet()) {
-            Bundle entryBundle = new Bundle();
-            entryBundle.putBoolean("display", entry.getValue().isDisplayable());
-            bundle.putBundle(entry.getKey(), entryBundle);
+    // Convert current entries to JSON format for persistence
+    public String toJsonString() {
+        try {
+            JSONObject jsonObject = new JSONObject();
+            for (Map.Entry<String, UnlockEntry> entry : entries.entrySet()) {
+                JSONObject entryJson = new JSONObject();
+                entryJson.put("display", entry.getValue().isDisplayable());
+                jsonObject.put(entry.getKey(), entryJson);
+            }
+            return jsonObject.toString();
+        } catch (JSONException e) {
+            MyLog.e("UnlockOptions: failed to convert to JSON: " + e);
+            return null;
         }
-        return bundle;
     }
 
-    public static Map<String, Boolean> fromBundle(@Nullable Bundle bundle) {
-        Map<String, Boolean> result = new HashMap<>();
-        if (bundle == null) {
-            return result;
+    // Save unlock options to file
+    public static void toFile(Context context, String jsonString) {
+        if (jsonString == null) {
+            MyLog.w("UnlockOptions: Cannot save null JSON string");
+            return;
         }
-        for (String key : bundle.keySet()) {
-            Bundle entry = bundle.getBundle(key);
-            if (entry != null && entry.containsKey("display")) {
-                result.put(key, entry.getBoolean("display"));
+
+        File tempFile = new File(context.getFilesDir(), UNLOCK_OPTIONS_TEMP_FILE);
+        File finalFile = new File(context.getFilesDir(), UNLOCK_OPTIONS_FILE);
+        File lockFile = new File(context.getFilesDir(), UNLOCK_OPTIONS_LOCK_FILE);
+        RandomAccessFile randomAccessFile = null;
+        FileChannel channel = null;
+        FileLock lock = null;
+
+        try {
+            randomAccessFile = new RandomAccessFile(lockFile, "rw");
+            channel = randomAccessFile.getChannel();
+
+            try {
+                lock = channel.lock();
+            } catch (OverlappingFileLockException e) {
+                MyLog.e("UnlockOptions: Lock already held by this JVM: " + e);
+                return;
+            }
+
+            try {
+                // Write to temporary file first to ensure atomic update
+                try (FileOutputStream fos = new FileOutputStream(tempFile);
+                     OutputStreamWriter writer = new OutputStreamWriter(fos, "UTF-8")) {
+
+                    writer.write(jsonString);
+                    writer.flush();
+                    fos.getFD().sync();
+                }
+
+                // Atomic rename operation
+                if (!tempFile.renameTo(finalFile)) {
+                    MyLog.e("UnlockOptions: Failed to rename temp file to final file.");
+                }
+            } finally {
+                if (tempFile.exists()) {
+                    tempFile.delete();
+                }
+            }
+        } catch (IOException e) {
+            MyLog.e("UnlockOptions: failed to save unlock options: " + e);
+        } finally {
+            if (lock != null) {
+                try {
+                    lock.release();
+                } catch (IOException e) {
+                    MyLog.e("UnlockOptions: failed to release lock: " + e);
+                }
+            }
+            if (channel != null) {
+                try {
+                    channel.close();
+                } catch (IOException e) {
+                    MyLog.e("UnlockOptions: failed to close channel: " + e);
+                }
+            }
+            if (randomAccessFile != null) {
+                try {
+                    randomAccessFile.close();
+                } catch (IOException e) {
+                    MyLog.e("UnlockOptions: failed to close random access file: " + e);
+                }
             }
         }
-        return result;
+    }
+
+    // Read unlock options from file - returns Map<String, Boolean> for display flags
+    @SuppressWarnings("resource")
+    public static Map<String, Boolean> fromFile(Context context) {
+        File file = new File(context.getFilesDir(), UNLOCK_OPTIONS_FILE);
+        File lockFile = new File(context.getFilesDir(), UNLOCK_OPTIONS_LOCK_FILE);
+        Map<String, Boolean> unlockOptionsMap = new HashMap<>();
+        RandomAccessFile randomAccessFile = null;
+        FileChannel channel = null;
+        FileLock lock = null;
+
+        try {
+            randomAccessFile = new RandomAccessFile(lockFile, "rw");
+            channel = randomAccessFile.getChannel();
+
+            try {
+                lock = channel.lock(0L, Long.MAX_VALUE, true); // shared lock
+            } catch (OverlappingFileLockException e) {
+                MyLog.e("UnlockOptions: Read lock already held by this JVM: " + e);
+                return unlockOptionsMap;
+            }
+
+            if (file.exists()) {
+                try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+                    StringBuilder builder = new StringBuilder();
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        builder.append(line);
+                    }
+
+                    // Parse JSON and convert to Map
+                    JSONObject jsonObject = new JSONObject(builder.toString());
+                    Iterator<String> keys = jsonObject.keys();
+                    while (keys.hasNext()) {
+                        String key = keys.next();
+                        JSONObject entryJson = jsonObject.getJSONObject(key);
+                        boolean display = entryJson.optBoolean("display", true);
+                        unlockOptionsMap.put(key, display);
+                    }
+                }
+            }
+        } catch (IOException | JSONException e) {
+            MyLog.e("UnlockOptions: failed to read unlock options: " + e);
+        } finally {
+            if (lock != null) {
+                try {
+                    lock.release();
+                } catch (IOException e) {
+                    MyLog.e("UnlockOptions: failed to release lock: " + e);
+                }
+            }
+            if (channel != null) {
+                try {
+                    channel.close();
+                } catch (IOException e) {
+                    MyLog.e("UnlockOptions: failed to close channel: " + e);
+                }
+            }
+            if (randomAccessFile != null) {
+                try {
+                    randomAccessFile.close();
+                } catch (IOException e) {
+                    MyLog.e("UnlockOptions: failed to close random access file: " + e);
+                }
+            }
+        }
+
+        return unlockOptionsMap;
+    }
+
+    // Clear persisted unlock options
+    public static void clear(Context context) {
+        File file = new File(context.getFilesDir(), UNLOCK_OPTIONS_FILE);
+        File lockFile = new File(context.getFilesDir(), UNLOCK_OPTIONS_LOCK_FILE);
+        File tempFile = new File(context.getFilesDir(), UNLOCK_OPTIONS_TEMP_FILE);
+
+        if (file.exists()) {
+            if (!file.delete()) {
+                MyLog.w("UnlockOptions: Failed to delete unlock options file");
+            }
+        }
+        if (tempFile.exists()) {
+            if (!tempFile.delete()) {
+                MyLog.w("UnlockOptions: Failed to delete unlock options temp file");
+            }
+        }
+        if (lockFile.exists()) {
+            if (!lockFile.delete()) {
+                MyLog.w("UnlockOptions: Failed to delete unlock options lock file");
+            }
+        }
     }
 
     public boolean hasConduitEntry() {

--- a/app/src/main/res/layout/unlock_required_prompt_layout.xml
+++ b/app/src/main/res/layout/unlock_required_prompt_layout.xml
@@ -330,7 +330,7 @@
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:gravity="center_horizontal"
-                            android:text="@string/btn_disconnect"
+                            android:text="@string/label_dismiss"
                             android:textAppearance="@style/TextAppearance.AppCompat.Headline"
                             android:textStyle="normal" />
 

--- a/app/src/main/res/values-ar/pro-strings.xml
+++ b/app/src/main/res/values-ar/pro-strings.xml
@@ -36,20 +36,11 @@
     -->
     <string name="rate_with_unit_template">%1$s %2$s</string>
 
-    <!-- Unit labels used with 'rate_with_unit_template' for bit-per-second speeds. These represent: bits, kilobits, megabits, etc. per second. -->
-    <string name="rate_unit_bps_bits">bps</string>
     <string name="rate_unit_kbps_bits">Kbps</string>
     <string name="rate_unit_mbps_bits">Mbps</string>
     <string name="rate_unit_gbps_bits">Gbps</string>
-    <string name="rate_unit_tbps_bits">Tbps</string>
-    <string name="rate_unit_pbps_bits">Pbps</string>
-
-
     <!-- Text shown on the home tab under Psiphon speed limit label when the speed limit values are not available, like when the user just installed the app and the speed limit is not yet known -->
     <string name="speed_rate_limit_not_available">غير متوفر</string>
-
-    <!-- Text shown on the home tab under Psiphon speed limit label when the there is no speed limit, like when the user has an unlimited subscription, for example -->
-    <string name="speed_rate_limit_no_limit">بلا حدود</string>
 
     <!-- Text on button beside speed limit (if it's not unlimited). This button leads the user to
          the workflow to subscribe for premium access. -->
@@ -241,14 +232,6 @@
 
     <!-- Generic billing error message seen by user if there is a billing problem with the PsiCash purchase. Do not translate or transliterate word PsiCash -->
     <string name="psicash_purchase_not_available_error_message">شراء PsiCash غير متاح حاليًا. يُرجى المحاولة مجددًا في وقتٍ لاحق.</string>
-
-    <!-- An updated alert message seen by the user when they try to use one of Speed Boost options but their PsiCash balance is insufficient.
-    Note that since we are phasing out the PsiCash system, this message is no longer offering the user to buy more PsiCash, and is just informing
-    them that they do not have enough PsiCash to activate the Speed Boost option.
-    'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through
-    Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that
-    indicates a fast or unrestricted speed.-->
-    <string name="speed_boost_insufficient_balance_alert_update">ليس لديك ما يكفي من PsiCash لتفعيل خيار تعزيز السرعة</string>
 
     <!-- Title of the tolbar notification which is shown to the user when Psiphon server detects an unsupported Internet traffic request  -->
     <string name="disallowed_traffic_alert_notification_title">ترقية Psiphon Pro</string>
@@ -513,12 +496,6 @@
     <!--Title of button that disconnects the VPN. -->
     <string name="btn_disconnect">قطع الاتصال</string>
 
-    <!--Do not translate or transliterate 'Psiphon'. An alert dialog with this title is shown when the user connects from a region where free service is no longer offered, asking the user to choose an option to continue using the app.-->
-    <string name="purchase_required_prompt_title">كيفية الوصول إلى Psiphon في منطقتك</string>
-
-    <!--Do not translate or transliterate 'Psiphon'. Body of an alert which is shown when the user connects from a region where free service is no longer offered, asking the user to choose an option to continue using the app.-->
-    <string name="unlock_required_prompt_body">يتطلب الوصول إلى Psiphon في منطقتك الآن دعمك. ساعد في إبقاء Psiphon متاحًا لمن هم في أمسّ الحاجة إليه باختيار خيار متاح للمتابعة.</string>
-
     <!-- Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. -->
     <string name="speed_boost_product_1_hr">ساعة</string>
 
@@ -603,20 +580,4 @@
     <!-- Description for the 'Update' action to open the Play Store page for the Psiphon Pro app, do not translate or transliterate 'Psiphon Pro'. -->
     <string name="update_psiphon_pro_action_description">تحديث إلى أحدث إصدار من Psiphon Pro للوصول إلى هذه الميزة</string>
 
-    <!-- Access status label shown on the home tab when the user has a limited subscription plan -->
-    <string name="subscription_limited">الاشتراك محدود</string>
-
-    <!-- Access status label shown on the home tab when the user has an unlimited subscription plan -->
-    <string name="subscription_unlimited">الاشتراك: غير محدود</string>
-
-    <!-- Access status label shown on the home tab when the user has time pass plan. A time pass is a single use license that is valid for a certain
-    period of time from the moment it is purchased and does not automatically renew after its expiry, unlike a subscription -->
-    <string name="time_pass_active">تايم باس: مُفَعَّل</string>
-
-    <!-- Access status label shown on the home tab when the user has no subscription or time pass plan -->
-    <string name="subscription_none">الدخول مجاني</string>
-
-    <!-- Access status label shown on the home tab when the user is running the Conduit app on the same device which may provide enhanced access to Psiphon.
-     Do not translate or transliterate 'Conduit'. -->
-    <string name="conduit_active">Conduit: مُفَعَّل</string>
-</resources>
+    </resources>

--- a/app/src/main/res/values/pro-strings.xml
+++ b/app/src/main/res/values/pro-strings.xml
@@ -614,4 +614,13 @@
     <!-- Access status label shown on the home tab when the user is running the Conduit app on the same device which may provide enhanced access to Psiphon.
      Do not translate or transliterate 'Conduit'. -->
     <string name="conduit_active">Conduit: Active</string>
+
+    <!-- Short (collapsed) notification text shown when the user is connected to Psiphon but their access is blocked due to a region restriction and they need to unlock access. Do not translate or transliterate 'Psiphon'. -->
+    <string name="notification_text_unlock_required_short">Psiphon access blocked. Tap to learn more</string>
+
+    <!-- Long (expanded) notification text shown when the user is connected to Psiphon but their access is blocked due to a region restriction and they need to unlock access. Do not translate or transliterate 'Psiphon'. -->
+    <string name="notification_text_unlock_required_long">Free access to Psiphon is no longer available in your region. Tap to see unlock options</string>
+
+    <!-- Generic 'Dismiss' button label for dialogs and alerts -->
+    <string name="label_dismiss">Dismiss</string>
 </resources>


### PR DESCRIPTION
- Persist unlock options to file since service shuts down immediately
- Move unlock check to onResume() for consistent handling regardless of app entry method
- Replace Bundle serialization with JSON file persistence
- Eliminate special unlock intent action in favor of regular VIEW intent
- Simplify notification flow and remove complex intent handling
- Change dialog button from "Disconnect" to "Dismiss" for accuracy
- Remove auto-dismiss subscription since service stops before dialog shows
- New text for unlock required notification