### PR TITLE
Fix unreliable ConduitStateManager state emission and completion

### DIFF
--- a/app/src/main/java/com/psiphon3/ConduitState.java
+++ b/app/src/main/java/com/psiphon3/ConduitState.java
@@ -21,6 +21,7 @@ public abstract class ConduitState {
         NOT_INSTALLED,
         INCOMPATIBLE_VERSION,
         UNSUPPORTED_SCHEMA,
+        ERROR,
     }
 
     @NonNull
@@ -54,6 +55,13 @@ public abstract class ConduitState {
 
     public static ConduitState fromJson(String jsonString) throws IllegalArgumentException {
         return Parser.INSTANCE.parse(jsonString);
+    }
+
+    public static ConduitState error(String message) {
+        return builder()
+                .setStatus(Status.ERROR)
+                .setMessage(message)
+                .build();
     }
 
     private enum Parser {

--- a/app/src/main/java/com/psiphon3/HomeTabFragment.java
+++ b/app/src/main/java/com/psiphon3/HomeTabFragment.java
@@ -155,9 +155,14 @@ public class HomeTabFragment extends Fragment {
                         // If tunnel is not running, check if Conduit is running directly
                         return ConduitStateManager.newManager(requireContext()).stateFlowable()
                                 .filter(state -> state.status() != ConduitState.Status.UNKNOWN)
+                                .doOnNext(state -> {
+                                            if (state.status() == ConduitState.Status.ERROR) {
+                                                // Log the error state
+                                                MyLog.e("HomeTabFragment: error getting Conduit state: " + state.message());
+                                            }
+                                        })
                                 .map(state -> state.status() == ConduitState.Status.RUNNING)
-                                .doOnError(throwable -> MyLog.e("HomeTabFragment: error getting conduit state", throwable))
-                                .onErrorReturnItem(false);
+                                .onErrorReturnItem(false); // Should never happen, but just in case
                     }
                 })
                 .distinctUntilChanged();

--- a/app/src/main/java/com/psiphon3/UnlockRequiredDialog.java
+++ b/app/src/main/java/com/psiphon3/UnlockRequiredDialog.java
@@ -217,7 +217,11 @@ public class UnlockRequiredDialog implements DefaultLifecycleObserver {
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe(
                                 this::updateConduitUI,
-                                throwable -> hideConduitUI()
+                                throwable ->
+                                {
+                                    MyLog.e("UnlockRequiredDialog: unexpected error while observing Conduit state" + throwable);
+                                    hideConduitUI();
+                                }
                         );
         compositeDisposable.add(updateStateDisposable);
     }
@@ -245,6 +249,12 @@ public class UnlockRequiredDialog implements DefaultLifecycleObserver {
                 installConduitView.setVisibility(View.GONE);
                 openConduitView.setVisibility(View.GONE);
                 updatePsiphonProView.setVisibility(View.GONE);
+                break;
+            case ERROR:
+                // Error state, hide all Conduit views
+                MyLog.e("UnlockRequiredDialog: Conduit error: " +
+                        (state.message() != null ? state.message() : "unknown error"));
+                hideConduitUI();
                 break;
             case RUNNING:
                 // Conduit is running, close the dialog


### PR DESCRIPTION
- Replace BehaviorProcessor with BehaviorRelay for thread-safe state emission
- Add ERROR status to ConduitState enum
- Remove emitStateAndComplete() causing race conditions
- Add terminal state detection with takeUntil() for proper stream completion
- Update consumers to handle ERROR states instead of exceptions
- Add explicit timeout error message for Conduit state initialization in TunnelManager