### PR TITLE
Add missing unlock  UI AI translations

### DIFF
--- a/app/src/main/res/values-am/pro-strings.xml
+++ b/app/src/main/res/values-am/pro-strings.xml
@@ -231,4 +231,18 @@
     <!-- Access status label shown on the home tab when the user is running the Conduit app on the same device which may provide enhanced access to Psiphon. Do not translate or transliterate 'Conduit'. -->
     <string name="conduit_active">Conduit፦ ሰራተኛ</string>
 
-    </resources>
+    <!--Do not translate or transliterate 'Psiphon'. An alert dialog with this title is shown when the user connects from a region where free service is no longer offered, asking the user to choose an option to continue using the app.-->
+    <string name="purchase_required_prompt_title">እንዴት በአካባቢዎ ውስጥ Psiphon ማግኘት ይቻላል።</string>
+
+    <!--Do not translate or transliterate 'Psiphon'. Body of an alert which is shown when the user connects from a region where free service is no longer offered, asking the user to choose an option to continue using the app.-->
+    <string name="unlock_required_prompt_body">በአካባቢዎ ውስጥ Psiphon ማግኘት አሁን የእርስዎን ድጋፍ ይፈልጋል። Psiphon ለበጎ አሳሳቢዎች እንዲቀጥል በሚችሉበት መንገድ ይምረጡ።</string>
+
+    <!-- Short (collapsed) notification text shown when the user is connected to Psiphon but their access is blocked due to a region restriction and they need to unlock access. Do not translate or transliterate 'Psiphon'. -->
+    <string name="notification_text_unlock_required_short">የPsiphon መዳረሻ ታግዷል። ለተጨማሪ መረጃ ይንኩ</string>
+
+    <!-- Long (expanded) notification text shown when the user is connected to Psiphon but their access is blocked due to a region restriction and they need to unlock access. Do not translate or transliterate 'Psiphon'. -->
+    <string name="notification_text_unlock_required_long">በአካባቢዎ ውስጥ ነጻ የPsiphon መዳረሻ አልተገኘም። የመክፈቻ አማራጮችን ለማየት ይንኩ</string>
+
+    <!-- Generic 'Dismiss' button label for dialogs and alerts -->
+    <string name="label_dismiss">ዝጋ</string>
+</resources>

--- a/app/src/main/res/values-az/pro-strings.xml
+++ b/app/src/main/res/values-az/pro-strings.xml
@@ -124,4 +124,18 @@
     <string name="subscription_none">Pulsuz Gələcuk</string>
     <string name="conduit_active">Conduit: Aktiv</string>
 
-    </resources>
+    <!--Do not translate or transliterate 'Psiphon'. An alert dialog with this title is shown when the user connects from a region where free service is no longer offered, asking the user to choose an option to continue using the app.-->
+    <string name="purchase_required_prompt_title">Sizin bölgənizdə Psiphon-a necə daxil olmaq olar.</string>
+
+    <!--Do not translate or transliterate 'Psiphon'. Body of an alert which is shown when the user connects from a region where free service is no longer offered, asking the user to choose an option to continue using the app.-->
+    <string name="unlock_required_prompt_body">Sizin bölgənizdə Psiphon-a giriş indi sizin dəstəyinizi tələb edir. Ən çox ehtiyacı olanlar üçün Psiphon-un əlçatan qalmasına kömək etmək üçün davam etmək üçün mövcud variantlardan birini seçin.</string>
+
+    <!-- Short (collapsed) notification text shown when the user is connected to Psiphon but their access is blocked due to a region restriction and they need to unlock access. Do not translate or transliterate 'Psiphon'. -->
+    <string name="notification_text_unlock_required_short">Psiphon-a giriş bloklanıb. Ətraflı öyrənmək üçün toxunun</string>
+
+    <!-- Long (expanded) notification text shown when the user is connected to Psiphon but their access is blocked due to a region restriction and they need to unlock access. Do not translate or transliterate 'Psiphon'. -->
+    <string name="notification_text_unlock_required_long">Sizin bölgənizdə Psiphon-a pulsuz giriş artıq mövcud deyil. Açmaq üçün variantlara baxmaq üçün toxunun</string>
+
+    <!-- Generic 'Dismiss' button label for dialogs and alerts -->
+    <string name="label_dismiss">Bağla</string>
+</resources>

--- a/app/src/main/res/values-be/pro-strings.xml
+++ b/app/src/main/res/values-be/pro-strings.xml
@@ -157,4 +157,18 @@
     <string name="subscription_none">Бесплатны доступ</string>
     <string name="conduit_active">Conduit: Актыўны</string>
 
-    </resources>
+    <!--Do not translate or transliterate 'Psiphon'. An alert dialog with this title is shown when the user connects from a region where free service is no longer offered, asking the user to choose an option to continue using the app.-->
+    <string name="purchase_required_prompt_title">Як атрымаць доступ да Psiphon у вашым рэгіёне.</string>
+
+    <!--Do not translate or transliterate 'Psiphon'. Body of an alert which is shown when the user connects from a region where free service is no longer offered, asking the user to choose an option to continue using the app.-->
+    <string name="unlock_required_prompt_body">Доступ да Psiphon у вашым рэгіёне цяпер патрабуе вашай падтрымкі. Дапамажыце захаваць Psiphon даступным для тых, хто мае найбольшую патрэбу, выбраўшы адзін з даступных варыянтаў для працягу.</string>
+
+    <!-- Short (collapsed) notification text shown when the user is connected to Psiphon but their access is blocked due to a region restriction and they need to unlock access. Do not translate or transliterate 'Psiphon'. -->
+    <string name="notification_text_unlock_required_short">Доступ да Psiphon заблакаваны. Націсніце, каб даведацца больш</string>
+
+    <!-- Long (expanded) notification text shown when the user is connected to Psiphon but their access is blocked due to a region restriction and they need to unlock access. Do not translate or transliterate 'Psiphon'. -->
+    <string name="notification_text_unlock_required_long">Бясплатны доступ да Psiphon у вашым рэгіёне больш недаступны. Націсніце, каб убачыць варыянты разблакіроўкі</string>
+
+    <!-- Generic 'Dismiss' button label for dialogs and alerts -->
+    <string name="label_dismiss">Закрыць</string>
+</resources>

--- a/app/src/main/res/values-bn/pro-strings.xml
+++ b/app/src/main/res/values-bn/pro-strings.xml
@@ -158,4 +158,18 @@
     <string name="subscription_none">বিনামূল্যে অ্যাক্সেস</string>
     <string name="conduit_active">Conduit: সক্রিয়</string>
 
-    </resources>
+    <!--Do not translate or transliterate 'Psiphon'. An alert dialog with this title is shown when the user connects from a region where free service is no longer offered, asking the user to choose an option to continue using the app.-->
+    <string name="purchase_required_prompt_title">আপনার অঞ্চলে Psiphon-এ কীভাবে প্রবেশ করবেন।</string>
+
+    <!--Do not translate or transliterate 'Psiphon'. Body of an alert which is shown when the user connects from a region where free service is no longer offered, asking the user to choose an option to continue using the app.-->
+    <string name="unlock_required_prompt_body">আপনার অঞ্চলে Psiphon-এ প্রবেশ এখন আপনার সহায়তা প্রয়োজন। সবচেয়ে বেশি প্রয়োজন এমন মানুষের জন্য Psiphon-কে প্রবেশযোগ্য রাখতে সাহায্য করুন, চালিয়ে যেতে একটি উপলব্ধ বিকল্প নির্বাচন করুন।</string>
+
+    <!-- Short (collapsed) notification text shown when the user is connected to Psiphon but their access is blocked due to a region restriction and they need to unlock access. Do not translate or transliterate 'Psiphon'. -->
+    <string name="notification_text_unlock_required_short">Psiphon প্রবেশ বন্ধ। আরও জানতে ট্যাপ করুন</string>
+
+    <!-- Long (expanded) notification text shown when the user is connected to Psiphon but their access is blocked due to a region restriction and they need to unlock access. Do not translate or transliterate 'Psiphon'. -->
+    <string name="notification_text_unlock_required_long">আপনার অঞ্চলে Psiphon-এ বিনামূল্যে প্রবেশ আর উপলব্ধ নেই। আনলক বিকল্প দেখতে ট্যাপ করুন</string>
+
+    <!-- Generic 'Dismiss' button label for dialogs and alerts -->
+    <string name="label_dismiss">বন্ধ করুন</string>
+</resources>

--- a/app/src/main/res/values-bo/pro-strings.xml
+++ b/app/src/main/res/values-bo/pro-strings.xml
@@ -134,4 +134,18 @@
     <string name="subscription_none">རིན་ལང་ ཞུག་ལམ</string>
     <string name="conduit_active">Conduit། ལས་བོ་བོས</string>
 
-    </resources>
+    <!--Do not translate or transliterate 'Psiphon'. An alert dialog with this title is shown when the user connects from a region where free service is no longer offered, asking the user to choose an option to continue using the app.-->
+    <string name="purchase_required_prompt_title">ཁྱེད་ཀྱི་ས་ཁུལ་ནང་ Psiphon ལ་འཛུལ་སྤྱོད་བྱེད་པའི་ཐབས།</string>
+
+    <!--Do not translate or transliterate 'Psiphon'. Body of an alert which is shown when the user connects from a region where free service is no longer offered, asking the user to choose an option to continue using the app.-->
+    <string name="unlock_required_prompt_body">ཁྱེད་ཀྱི་ས་ཁུལ་ནང་ Psiphon ལ་འཛུལ་སྤྱོད་བྱེད་པ་ད་ལྟ་ཁྱེད་ཀྱི་རྒྱབ་སྐྱོར་དགོས་ཡོད། དགོས་མཁོ་ཆེ་བའི་མི་ཚུལ་ལ་དངོས་སུ་འཛུལ་སྤྱོད་བྱེད་པའི་ཐབས་འདེམས།</string>
+
+    <!-- Short (collapsed) notification text shown when the user is connected to Psiphon but their access is blocked due to a region restriction and they need to unlock access. Do not translate or transliterate 'Psiphon'. -->
+    <string name="notification_text_unlock_required_short">Psiphon ལ་འཛུལ་སྤྱོད་བྱེད་པ་བཀག་འགོག་བྱས་ཡོད། ཧེང་བཀོད་བྱས་ན་ཧེང་བརྡ་དོན་ཤེས་ཐུབ།</string>
+
+    <!-- Long (expanded) notification text shown when the user is connected to Psiphon but their access is blocked due to a region restriction and they need to unlock access. Do not translate or transliterate 'Psiphon'. -->
+    <string name="notification_text_unlock_required_long">ཁྱེད་ཀྱི་ས་ཁུལ་ནང་ Psiphon ལ་སྤྱོད་མི་འདི་ད་ལྟ་རང་རེད་མི་འདུག ཧེང་བཀོད་བྱས་ན་སྒོ་ཕྱེ་ཐབས་ཚུལ་ལ་ལེན་ཐུབ།</string>
+
+    <!-- Generic 'Dismiss' button label for dialogs and alerts -->
+    <string name="label_dismiss">རྩིས་བཏོན།</string>
+</resources>


### PR DESCRIPTION
Done with the help of the Android Studio GitHub Copilot plugin in the new codebase context-aware agent mode.