### PR TITLE
Upgrade to targetSdkVersion 35 (Android 15) with edge-to-edge opt-out

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,8 @@ android {
                 applicationId "com.psiphon3"
                 resValue "string", "tray__authority", "${applicationId}.tray"
                 minSdkVersion 14
-                compileSdk 34
-                targetSdkVersion 34
+                compileSdk 35
+                targetSdkVersion 35
                 versionCode verCode
                 versionName verName
                 testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,7 +39,7 @@
         android:fullBackupContent="false"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:theme="@style/Theme.AppCompat"
+        android:theme="@style/Theme.Psiphon"
         android:supportsRtl="true"
         android:label="@string/app_name"
         android:usesCleartextTraffic="false"

--- a/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
@@ -434,6 +434,7 @@ public class TunnelManager implements PsiphonTunnel.HostService, VpnManager.VpnS
 
     private void stopAndWaitForTunnel() {
         if (m_tunnelThread == null) {
+            MyLog.i("TunnelManager: stopAndWaitForTunnel called but m_tunnelThread is null.");
             return;
         }
 
@@ -441,12 +442,20 @@ public class TunnelManager implements PsiphonTunnel.HostService, VpnManager.VpnS
         // If it has not been called, then manually attempt to count down the latch here.
         // If the countdown hasn't been initiated, the `join` call may block the calling thread, potentially delaying execution.
         if (m_tunnelThreadStopSignal != null) {
+            if (m_tunnelThreadStopSignal.getCount() > 1) {
+                MyLog.e("TunnelManager: stopAndWaitForTunnel called but m_tunnelThreadStopSignal count is more than 1: " + m_tunnelThreadStopSignal.getCount());
+            }
+
+            MyLog.i("TunnelManager: counting down m_tunnelThreadStopSignal with count: " + m_tunnelThreadStopSignal.getCount());
             m_tunnelThreadStopSignal.countDown();
         }
 
         try {
+            MyLog.i("TunnelManager: Waiting for tunnel thread to stop.");
             m_tunnelThread.join();
+            MyLog.i("TunnelManager: Tunnel thread stopped.");
         } catch (InterruptedException e) {
+            MyLog.w("TunnelManager: Interrupted while waiting for tunnel thread to stop.");
             Thread.currentThread().interrupt();
         }
         m_tunnelThreadStopSignal = null;

--- a/app/src/main/res/layout/main_activity.xml
+++ b/app/src/main/res/layout/main_activity.xml
@@ -114,6 +114,7 @@
                 android:layout_height="8dp"
                 android:layout_alignTop="@+id/buttonPanel"
                 android:background="@drawable/connection_waiting_network_animation_drawable"
+                android:orientation="horizontal"
                 android:visibility="invisible" />
             <ProgressBar
                 android:id="@+id/connectionProgressBar"

--- a/app/src/main/res/values-v35/styles.xml
+++ b/app/src/main/res/values-v35/styles.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="Theme.Psiphon" parent="Theme.AppCompat">
+        <!-- workaround for opting out of edge-to-edge enforcement, v35+ specific -->
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
+    <style name="Theme.Psiphon" parent="Theme.AppCompat">
+        <!-- workaround for opting out of edge-to-edge enforcement, see v35+ specific styles -->
+    </style>
     <style name="Theme.DialogAlert" parent="Theme.AppCompat.Dialog.Alert">
         <item name="android:windowIsFloating">true</item>
         <item name="windowActionBar">false</item>


### PR DESCRIPTION
- Update compileSdk and targetSdkVersion to 35
- Add Theme.Psiphon with windowOptOutEdgeToEdgeEnforcement for API 35+ to prevent edge-to-edge layout
- Add TunnelManager logging for improved debugging