### PR TITLE
Fix preselection for "tunnel-only" VPN mode

### DIFF
--- a/app/src/main/java/com/psiphon3/psiphonlibrary/InstalledAppsMultiSelectListPreference.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/InstalledAppsMultiSelectListPreference.java
@@ -19,7 +19,6 @@
 
 package com.psiphon3.psiphonlibrary;
 
-import android.Manifest;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
@@ -146,11 +145,22 @@ class InstalledAppsMultiSelectListPreference extends AlertDialog.Builder impleme
         );
         PackageManager pm = context.getPackageManager();
 
+        // Get currently selected apps so we can show them even if they lack
+        // INTERNET permission, see below for details
+        Set<String> currentlySelected = whitelist ?
+                VpnAppsUtils.getPendingAppsIncludedInVpn(context) :
+                VpnAppsUtils.getPendingAppsExcludedFromVpn(context);
+
         List<AppEntry> apps = new ArrayList<>();
         List<PackageInfo> packages = pm.getInstalledPackages(PackageManager.GET_PERMISSIONS);
 
         for (PackageInfo p : packages) {
-            if (isInternetPermissionGranted(p)) {
+            // Always show currently selected apps even if they lack INTERNET permission
+            // This allows users to see them in the UI and unselect, making sure
+            // they don't get stuck in the VPN exclusion/inclusion list forever
+            // if they got there by some other means (e.g. adb, old app version, etc)
+            if (VpnAppsUtils.hasInternetPermission(p) ||
+                    currentlySelected.contains(p.packageName)) {
                 // This takes a bit of time, but since we want the apps sorted by displayed name
                 // its best to do synchronously
                 String appName = p.applicationInfo.loadLabel(pm).toString();
@@ -180,17 +190,6 @@ class InstalledAppsMultiSelectListPreference extends AlertDialog.Builder impleme
 
         // Hide apps that match any VPN rules for their installed version
         return VpnRulesHelper.matchesAnyVpnRule(packageId, versionCode);
-    }
-
-    private boolean isInternetPermissionGranted(PackageInfo pkgInfo) {
-        if (pkgInfo.requestedPermissions != null) {
-            for (String permission : pkgInfo.requestedPermissions) {
-                if (Manifest.permission.INTERNET.equals(permission)) {
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 
     private Single<Drawable> getIconLoader(final ApplicationInfo applicationInfo, final PackageManager packageManager) {

--- a/app/src/main/java/com/psiphon3/psiphonlibrary/VpnAppsUtils.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/VpnAppsUtils.java
@@ -19,9 +19,11 @@
 
 package com.psiphon3.psiphonlibrary;
 
+import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
@@ -251,16 +253,45 @@ public class VpnAppsUtils {
         // Try and put default package ID first by matching DEFAULT_ONLY
         List<ResolveInfo> matchingActivities = packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
         for (ResolveInfo info : matchingActivities) {
-            packageIds.add(info.activityInfo.packageName);
+            String packageName = info.activityInfo.packageName;
+            // Only add if app has INTERNET permission to match UI filtering
+            if (hasInternetPermission(packageManager, packageName)) {
+                packageIds.add(packageName);
+            }
         }
 
         // Next add all other packages able to handle the intent by matching ALL
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             matchingActivities = packageManager.queryIntentActivities(intent, PackageManager.MATCH_ALL);
             for (ResolveInfo info : matchingActivities) {
-                packageIds.add(info.activityInfo.packageName);
+                String packageName = info.activityInfo.packageName;
+                // Only add if app has INTERNET permission to match UI filtering
+                if (hasInternetPermission(packageManager, packageName)) {
+                    packageIds.add(packageName);
+                }
             }
         }
         return packageIds;
+    }
+
+    private static boolean hasInternetPermission(PackageManager pm, String packageName) {
+        try {
+            PackageInfo packageInfo = pm.getPackageInfo(packageName, PackageManager.GET_PERMISSIONS);
+            return hasInternetPermission(packageInfo);
+        } catch (PackageManager.NameNotFoundException e) {
+            // App not found
+            return false;
+        }
+    }
+
+    public static boolean hasInternetPermission(PackageInfo packageInfo) {
+        if (packageInfo.requestedPermissions != null) {
+            for (String permission : packageInfo.requestedPermissions) {
+                if (Manifest.permission.INTERNET.equals(permission)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Prevents browser preselection from picking apps that handle HTTP intents but lack INTERNET permission, which created invisible selections users couldn't deselect. Additionally, UI now shows already-selected apps without INTERNET permission so users can clean up any existing bad selections.