### PR TITLE
Fix VPN exclusions logging accuracy

### DIFF
--- a/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
@@ -1108,8 +1108,6 @@ public class TunnelManager implements PsiphonTunnel.HostService, VpnManager.VpnS
                             } catch (PackageManager.NameNotFoundException e) {
                                 MyLog.w("TunnelManager: VpnBuilder: failed to add " + packageId + " to allowed VPN applications, package not found");
                             }
-                        } else {
-                            MyLog.w("TunnelManager: VpnBuilder: failed to add " + packageId + " to allowed VPN applications, version rules or trust verification failed");
                         }
                     }
 
@@ -1181,8 +1179,6 @@ public class TunnelManager implements PsiphonTunnel.HostService, VpnManager.VpnS
                             } catch (PackageManager.NameNotFoundException e) {
                                 MyLog.w("TunnelManager: VpnBuilder: failed to add " + packageId + " to disallowed VPN applications, package not found");
                             }
-                        } else {
-                            MyLog.w("TunnelManager: VpnBuilder: failed to add " + packageId + " to disallowed VPN applications, version rules or trust verification failed");
                         }
                     }
                 } else {
@@ -1219,8 +1215,6 @@ public class TunnelManager implements PsiphonTunnel.HostService, VpnManager.VpnS
                             } catch (PackageManager.NameNotFoundException e) {
                                 MyLog.w("TunnelManager: VpnBuilder: failed to add " + packageId + " to disallowed VPN applications, package not found");
                             }
-                        } else {
-                            MyLog.w("TunnelManager: VpnBuilder: failed to add " + packageId + " to disallowed VPN applications, version rules or trust verification failed");
                         }
                     }
                 }
@@ -1897,6 +1891,7 @@ public class TunnelManager implements PsiphonTunnel.HostService, VpnManager.VpnS
     private boolean shouldAlwaysExcludeFromVpn(PackageManager pm, String packageId) {
         // First check if the app is installed
         if (!PackageHelper.isPackageInstalled(pm, packageId)) {
+            MyLog.i("TunnelManager: VpnBuilder: " + packageId + " not installed, skipping exclusion");
             return false;
         }
 
@@ -1913,13 +1908,20 @@ public class TunnelManager implements PsiphonTunnel.HostService, VpnManager.VpnS
 
             // Check if version matches always-exclude rules
             if (!VpnRulesHelper.matchesAlwaysExcludeRule(packageId, versionCode)) {
+                MyLog.i("TunnelManager: VpnBuilder: " + packageId + " version does not match exclusion rules, skipping");
                 return false; // Version doesn't match always-exclude rules
             }
 
             // Finally check signature verification
-            return PackageHelper.verifyTrustedPackage(pm, packageId);
+            if (!PackageHelper.verifyTrustedPackage(pm, packageId)) {
+                MyLog.w("TunnelManager: VpnBuilder: " + packageId + " failed trust verification, skipping exclusion");
+                return false;
+            }
+
+            return true;
 
         } catch (PackageManager.NameNotFoundException e) {
+            MyLog.i("TunnelManager: VpnBuilder: " + packageId + " package not found, skipping exclusion");
             return false;
         }
     }
@@ -1928,6 +1930,7 @@ public class TunnelManager implements PsiphonTunnel.HostService, VpnManager.VpnS
     private boolean shouldAlwaysIncludeInVpn(PackageManager pm, String packageId) {
         // First check if the app is installed
         if (!PackageHelper.isPackageInstalled(pm, packageId)) {
+            MyLog.i("TunnelManager: VpnBuilder: " + packageId + " not installed, skipping inclusion");
             return false;
         }
 
@@ -1944,13 +1947,20 @@ public class TunnelManager implements PsiphonTunnel.HostService, VpnManager.VpnS
 
             // Check if version matches always-include rules
             if (!VpnRulesHelper.matchesAlwaysIncludeRule(packageId, versionCode)) {
+                MyLog.i("TunnelManager: VpnBuilder: " + packageId + " version does not match inclusion rules, skipping");
                 return false; // Version doesn't match always-include rules
             }
 
             // Finally check signature verification
-            return PackageHelper.verifyTrustedPackage(pm, packageId);
+            if (!PackageHelper.verifyTrustedPackage(pm, packageId)) {
+                MyLog.w("TunnelManager: VpnBuilder: " + packageId + " failed trust verification, skipping inclusion");
+                return false;
+            }
+
+            return true;
 
         } catch (PackageManager.NameNotFoundException e) {
+            MyLog.i("TunnelManager: VpnBuilder: " + packageId + " package not found, skipping inclusion");
             return false;
         }
     }


### PR DESCRIPTION
Previously, the logging in shouldAlwaysExcludeFromVpn and shouldAlwaysIncludeInVpn could produce misleading messages. For example, it might log "failed trust verification" or "version does not match rules" for apps that weren't even installed on the device.

Now the logging accurately reflects the actual reason why an app is being skipped in the VPN configuration process.