### PR TITLE
fix: set homePageHandled flag when handling home page

### DIFF
--- a/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
@@ -1137,6 +1137,10 @@ public class TunnelManager implements PsiphonTunnel.HostService, VpnManager.VpnS
     }
 
     private void sendHandshakeIntent() {
+        if (!homePageHandled.compareAndSet(false, true)) {
+            MyLog.i("TunnelManager: handshake intent already sent, skipping");
+            return;
+        }
         PendingIntent handshakePendingIntent = getPendingIntent(m_parentService, INTENT_ACTION_HANDSHAKE, getTunnelStateBundle());
         try {
             handshakePendingIntent.send();


### PR DESCRIPTION
Fixes the quiet/full restart logic triggered by the conduit state observer.