### PR TITLE
Add monochrome / themed icon

### DIFF
--- a/app/src/main/res/drawable-v24/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable-v24/ic_launcher_monochrome.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+  <group android:scaleX="0.14554687"
+      android:scaleY="0.14554687"
+      android:translateX="16.74"
+      android:translateY="16.74">
+    <group>
+      <path
+          android:pathData="m398,135.2l-26.1,183.2 -31.3,27.6h-119.3l-7.5,6.3 -8.6,83.7c-18,-2.3 -35.6,-6.9 -52.4,-13.7l37.5,-282.3 -93.3,0.1c9.3,-14.7 20.5,-28.2 33.3,-40.1h237.6c11.3,10.6 21.4,22.4 30.1,35.2zM337.8,159.2l-5.7,-6.3h-83.3l-6.8,6.3 -17.1,123.3 5.1,6.3h83.3l7.4,-6.3z"
+          android:fillColor="#ffffff"
+          android:fillType="evenOdd"/>
+    </group>
+  </group>
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>


### PR DESCRIPTION
I haven't built it successfully yet but it looks fine in Android Studio.
<img width="401" height="417" alt="Screenshot 2025-10-25 at 10 52 25 AM" src="https://github.com/user-attachments/assets/22f3d1f3-dd7d-428e-bb81-319a6f084774" />

Ref:

* https://developer.android.com/develop/ui/views/launch/icon_design_adaptive#add-to-your-app
* https://www.androidpolice.com/android-13-themed-icons-how-to-activate/