### PR TITLE
Allow MainActivity to handle screen size config changes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,7 +50,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:configChanges="orientation|screenSize"
+            android:configChanges="orientation|screenSize|smallestScreenSize"
             android:label="@string/app_name"
             android:exported="true"
             android:launchMode="singleTask">


### PR DESCRIPTION
Extend existing orientation handling with screenSize and smallestScreenSize to keep MainActivity alive on foldables.