### PR TITLE
Allow MainActivity to handle orientation config changes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,6 +51,7 @@
 
         <activity
             android:name="com.psiphon3.MainActivity"
+            android:configChanges="orientation|screenSize|smallestScreenSize"
             android:label="@string/app_name"
             android:exported="true"
             android:launchMode="singleTask">


### PR DESCRIPTION
Keep our portrait request in code, but add configChanges so if Google forces user rotation overrides on Pixel foldables/tablets the Activity stays alive and works.